### PR TITLE
🛡️ Sentinel: [HIGH] Fix overly permissive GITHUB_TOKEN in workflow

### DIFF
--- a/.github/workflows/0-start-exercise.yml
+++ b/.github/workflows/0-start-exercise.yml
@@ -6,9 +6,7 @@ on:
       - main
 
 permissions:
-  contents: write # Update Readme
-  actions: write # Disable/enable workflows
-  issues: write # Create issue and comment on issues
+  contents: read # Default to read-only for security
 
 env:
   STEP_1_FILE: ".github/steps/1-create-a-branch.md"
@@ -18,6 +16,10 @@ jobs:
     if: |
       !github.event.repository.is_template
     name: Start Exercise
+    permissions:
+      contents: write # Update Readme
+      actions: write # Disable/enable workflows
+      issues: write # Create issue and comment on issues
     uses: skills/exercise-toolkit/.github/workflows/start-exercise.yml@v0.8.1
     with:
       exercise-title: "Introduction to GitHub"
@@ -27,6 +29,10 @@ jobs:
     name: Post next step content
     runs-on: ubuntu-latest
     needs: [start_exercise]
+    permissions:
+      contents: write # Update Readme
+      actions: write # Disable/enable workflows
+      issues: write # Create issue and comment on issues
     env:
       ISSUE_REPOSITORY: ${{ github.repository }}
       ISSUE_NUMBER: ${{ needs.start_exercise.outputs.issue-number }}

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-19 - [Overly Permissive GITHUB_TOKEN Workflows]
+**Vulnerability:** Workflows grant global `contents: write` and `actions: write` permissions when only specific jobs require them.
+**Learning:** In GitHub Skills/Learning Lab course repositories, workflows often require `contents: write` to advance course progress (e.g., in `finish_exercise` jobs), or `actions: write` to enable/disable workflows. When hardening workflow permissions, apply restrictive permissions (e.g., `contents: read`) globally and delegate necessary `write` permissions only to the specific jobs that require them to mitigate risk of abuse or compromise.
+**Prevention:** Apply the principle of least privilege by setting global `permissions:` to `read-all` or minimum viable (e.g., `contents: read`) at the top of workflows, and then strictly define necessary `write` access at the individual `job` level only where required.


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `.github/workflows/0-start-exercise.yml` workflow was globally granting `contents: write`, `actions: write`, and `issues: write` permissions.
🎯 **Impact:** Overly permissive global workflow tokens can be abused if any malicious or compromised action is introduced, allowing write access to the entire repository and its settings.
🔧 **Fix:** Changed the global `permissions` to `contents: read` and moved the explicit `write` permissions exclusively to the `start_exercise` and `post_next_step_content` jobs that require them.
✅ **Verification:** Ran `actionlint` to verify YAML syntax and workflow validity. Code review has confirmed the fix.

---
*PR created automatically by Jules for task [8868283518701825763](https://jules.google.com/task/8868283518701825763) started by @DevAIEngine*