### PR TITLE
🛡️ Sentinel: [security improvement] Hardened GitHub Actions permissions

### DIFF
--- a/.github/workflows/1-create-a-branch.yml
+++ b/.github/workflows/1-create-a-branch.yml
@@ -11,9 +11,8 @@ on:
       - "my-first-branch"
 
 permissions:
+  # contents is intentionally restricted to read at the top-level to prevent unauthorized repository modifications
   contents: read
-  actions: write
-  issues: write
 
 env:
   STEP_2_FILE: ".github/steps/2-commit-a-file.md"
@@ -27,6 +26,10 @@ jobs:
     name: Post next step content
     needs: [find_exercise]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      issues: write
     env:
       ISSUE_REPOSITORY: ${{ github.repository }}
       ISSUE_NUMBER: ${{ needs.find_exercise.outputs.issue-number }}
@@ -66,16 +69,10 @@ jobs:
           file: exercise-toolkit/markdown-templates/step-feedback/watching-for-progress.md
 
       - name: Disable current workflow and enable next one
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           # 🛡️ Sentinel: Prevent command injection by using env var for workflow name
           gh workflow disable "$WORKFLOW_NAME"
-          gh workflow enable "Step 2"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-        run: |
-          gh workflow disable "${WORKFLOW_NAME}"
           gh workflow enable "Step 2"

--- a/.github/workflows/2-commit-a-file.yml
+++ b/.github/workflows/2-commit-a-file.yml
@@ -11,9 +11,8 @@ on:
       - "PROFILE.md"
 
 permissions:
+  # contents is intentionally restricted to read at the top-level to prevent unauthorized repository modifications
   contents: read
-  actions: write
-  issues: write
 
 env:
   STEP_3_FILE: ".github/steps/3-open-a-pull-request.md"
@@ -27,6 +26,10 @@ jobs:
     name: Post next step content
     needs: [find_exercise]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      issues: write
     env:
       ISSUE_REPOSITORY: ${{ github.repository }}
       ISSUE_NUMBER: ${{ needs.find_exercise.outputs.issue-number }}

--- a/.github/workflows/3-open-a-pull-request.yml
+++ b/.github/workflows/3-open-a-pull-request.yml
@@ -16,9 +16,8 @@ on:
       - edited
 
 permissions:
+  # contents is intentionally restricted to read at the top-level to prevent unauthorized repository modifications
   contents: read
-  actions: write
-  issues: write
 
 env:
   STEP_4_FILE: ".github/steps/4-merge-your-pull-request.md"
@@ -35,6 +34,10 @@ jobs:
     name: Check step work
     runs-on: ubuntu-latest
     needs: find_exercise
+    permissions:
+      contents: read
+      actions: write
+      issues: write
     env:
       ISSUE_REPOSITORY: ${{ github.repository }}
       ISSUE_NUMBER: ${{ needs.find_exercise.outputs.issue-number }}
@@ -115,6 +118,10 @@ jobs:
     name: Post next step content
     needs: [find_exercise, check_step_work]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      issues: write
     env:
       ISSUE_REPOSITORY: ${{ github.repository }}
       ISSUE_NUMBER: ${{ needs.find_exercise.outputs.issue-number }}

--- a/.github/workflows/4-merge-your-pull-request.yml
+++ b/.github/workflows/4-merge-your-pull-request.yml
@@ -63,16 +63,12 @@ jobs:
           file: ${{ env.REVIEW_FILE }}
 
       - name: Disable current workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           # 🛡️ Sentinel: Prevent command injection by using env var for workflow name
           gh workflow disable "$WORKFLOW_NAME"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-        run: gh workflow disable "${WORKFLOW_NAME}"
 
   finish_exercise:
     name: Finish Exercise


### PR DESCRIPTION
### 🛡️ Sentinel Security Improvement

**Vulnerability:** Overly permissive GitHub Actions permissions. 
**Impact:** Broad permissions, such as `actions: write` and `issues: write` at the global top-level of `.github/workflows/1-create-a-branch.yml`, `.github/workflows/2-commit-a-file.yml`, and `.github/workflows/3-open-a-pull-request.yml`, increase the blast radius if an action or dependent step is compromised, allowing unauthorized actions across the entire workflow execution context.
**Fix:** Applied the principle of least privilege. Restricted the top-level permissions to `contents: read` globally, and scoped `actions: write` and `issues: write` only to the explicit jobs that need them (e.g., `post_next_step_content`, `check_step_work`).
**Verification:** Validated the resulting workflow YAML files syntax using `actionlint`. Tested logic and confirmed proper job-level scoping of permissions.

---
*PR created automatically by Jules for task [226958230453560608](https://jules.google.com/task/226958230453560608) started by @DevAIEngine*