### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix exposed interactive debugger

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2023-10-24 - [Fix exposed Werkzeug interactive debugger on 0.0.0.0]
+**Vulnerability:** Flask `app.run` was hardcoded with `debug=True` and `host='0.0.0.0'`. This exposed the Werkzeug interactive debugger to all network interfaces, allowing arbitrary remote code execution (RCE).
+**Learning:** Hardcoding debug mode on a globally bound host (`0.0.0.0`) is a critical security vulnerability.
+**Prevention:** Always use environment variables (e.g., `FLASK_DEBUG`) to control debug mode, and ensure it defaults to `False` in production or default contexts.

--- a/app.py
+++ b/app.py
@@ -35,6 +35,8 @@ app.add_url_rule('/', view_func=optimize_tensor_stream, methods=['POST'])
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 8080))
-    app.run(host='0.0.0.0', port=port, debug=True)
+    # 🛡️ Sentinel: Removed debug=True to prevent exposing the Werkzeug interactive debugger on 0.0.0.0
+    debug_mode = os.environ.get('FLASK_DEBUG', 'False').lower() == 'true'
+    app.run(host='0.0.0.0', port=port, debug=debug_mode)
 
 # CORE-ENGINE-FINGERPRINT: QXVyb3JhX09TSVJJU19Db3JlX0VuZ2luZQ==


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Flask was running with `debug=True` while bound to `host='0.0.0.0'`. This exposed the Werkzeug interactive debugger on all network interfaces, allowing arbitrary remote code execution (RCE).
🎯 Impact: An attacker could execute arbitrary Python code on the server if an error occurs.
🔧 Fix: Removed hardcoded `debug=True` and instead check the `FLASK_DEBUG` environment variable, defaulting to `False`.
✅ Verification: Ran `pytest test_app.py` and `flake8` to ensure the application still functions normally and syntax is clean. Read `app.py` to confirm changes.

---
*PR created automatically by Jules for task [2918591288276419189](https://jules.google.com/task/2918591288276419189) started by @DevAIEngine*