### PR TITLE
🛡️ Sentinel: [HIGH] Fix unhandled exception and add input validation in generate-scenes endpoint

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Flask `app.run` was hardcoded with `debug=True` and `host='0.0.0.0'`. This exposed the Werkzeug interactive debugger to all network interfaces, allowing arbitrary remote code execution (RCE).
 **Learning:** Hardcoding debug mode on a globally bound host (`0.0.0.0`) is a critical security vulnerability.
 **Prevention:** Always use environment variables (e.g., `FLASK_DEBUG`) to control debug mode, and ensure it defaults to `False` in production or default contexts.
+## 2024-04-02 - [Fix unhandled exceptions and missing input validation in Veo API]
+**Vulnerability:** Unhandled exceptions in the '/veo-studio/generate-scenes' endpoint exposed the application to Denial of Service (DoS) attacks via malformed JSON payloads.
+**Learning:** Without strict type checking and validation of incoming JSON, unexpected types (like string instead of int) cause fatal TypeError and KeyError crashes in the Flask server.
+**Prevention:** Always validate that request.json is a dictionary and that required nested keys (like 'scenes' and numeric 'duration') are present and typed correctly before processing.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -119,11 +119,28 @@ def veo_generate():
 @app.route('/veo-studio/generate-scenes', methods=['POST'])
 def veo_generate_scenes():
     data = request.json
+
+    # Sentinel: Input validation to prevent unhandled KeyError/TypeError
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid request payload. Expected a JSON object."}), 400
+
+    scenes = data.get('scenes')
+    if not isinstance(scenes, list):
+        return jsonify({"error": "Invalid request payload. 'scenes' must be a list."}), 400
+
+    for scene in scenes:
+        if not isinstance(scene, dict):
+             return jsonify({"error": "Invalid request payload. Each scene must be a JSON object."}), 400
+        if 'duration' not in scene:
+             return jsonify({"error": "Invalid request payload. Each scene must contain a 'duration' field."}), 400
+        if not isinstance(scene['duration'], (int, float)):
+             return jsonify({"error": "Invalid request payload. 'duration' must be a number."}), 400
+
     return jsonify({
         "videoId": str(uuid.uuid4()),
         "videoUrl": f"/static/multi-scene.mp4",
-        "totalDuration": sum(s['duration'] for s in data.get('scenes', [])),
-        "sceneCount": len(data.get('scenes', [])),
+        "totalDuration": sum(s['duration'] for s in scenes),
+        "sceneCount": len(scenes),
         "status": "completed"
     })
 

--- a/test_generate_scenes.py
+++ b/test_generate_scenes.py
@@ -1,0 +1,25 @@
+import pytest
+from infrastructure.app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_generate_scenes_no_json(client):
+    rv = client.post('/veo-studio/generate-scenes', json="not_a_dict")
+    assert rv.status_code == 400
+
+def test_generate_scenes_invalid_scenes(client):
+    rv = client.post('/veo-studio/generate-scenes', json={'scenes': 'not_a_list'})
+    assert rv.status_code == 400
+
+def test_generate_scenes_invalid_duration(client):
+    rv = client.post('/veo-studio/generate-scenes', json={'scenes': [{'duration': 'string'}]})
+    assert rv.status_code == 400
+
+def test_generate_scenes_valid(client):
+    rv = client.post('/veo-studio/generate-scenes', json={'scenes': [{'duration': 10}, {'duration': 20}]})
+    assert rv.status_code == 200
+    assert rv.json['totalDuration'] == 30


### PR DESCRIPTION
**Severity:** HIGH
**Vulnerability:** Unhandled exceptions in the `/veo-studio/generate-scenes` endpoint exposed the application to Denial of Service (DoS) attacks. Because it assumed `request.json` had a specific structure without validation, malformed JSON payloads caused `TypeError` or `KeyError` crashes in the Flask server.
**Impact:** A malicious actor could repeatedly send invalid payloads to the endpoint, crashing worker processes and causing service disruption.
**Fix:** Added strict type checking for `request.json`, the `scenes` list, and the `duration` field. The endpoint now gracefully returns a `400 Bad Request` with an informative error message when invalid data is received.
**Verification:** Run `python3 -m pytest test_generate_scenes.py` to confirm that the endpoint correctly rejects invalid JSON, non-list `scenes`, and non-numeric `duration` fields with a 400 status code.

---
*PR created automatically by Jules for task [8525858412783943390](https://jules.google.com/task/8525858412783943390) started by @DevAIEngine*