### PR TITLE
🎨 Palette: Improve accessibility of emojis in buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-02 - Hide decorative emojis alongside visible text in buttons
+**Learning:** Overriding visible text in buttons with an `aria-label` to provide context for an emoji violates WCAG 2.5.3 (Label in Name).
+**Action:** When improving accessibility for buttons with visible text and decorative emojis, wrap the emojis in `<span aria-hidden="true">` to hide them from screen readers while preserving the accessible name derived from the visible text.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -167,10 +167,10 @@ export const NexusLegacyApp: React.FC = () => {
         <p style={{ fontSize: "32px", color: themeStyles.textColor, marginBottom: "60px" }}>What story shall we tell today?</p>
 
         <div style={{ display: "flex", flexDirection: "column", gap: "30px" }}>
-          <button onClick={() => setCurrentView("INTERVIEW")} style={massiveButtonStyle("#22c55e")}>🎙️ Tell a Story (Video Call)</button>
-          <button onClick={() => setIsVoiceOnlyMode(true)} style={massiveButtonStyle("#8b5cf6")}>🔮 Tell a Story (Voice Only)</button>
-          <button onClick={() => setCurrentView("WATCH")} style={massiveButtonStyle("#3b82f6")}>🍿 Watch My Life</button>
-          <button onClick={() => setCurrentView("LIVE")} style={massiveButtonStyle("#ef4444")}>📡 Go Live (Family Stream)</button>
+          <button onClick={() => setCurrentView("INTERVIEW")} style={massiveButtonStyle("#22c55e")}><span aria-hidden="true">🎙️</span> Tell a Story (Video Call)</button>
+          <button onClick={() => setIsVoiceOnlyMode(true)} style={massiveButtonStyle("#8b5cf6")}><span aria-hidden="true">🔮</span> Tell a Story (Voice Only)</button>
+          <button onClick={() => setCurrentView("WATCH")} style={massiveButtonStyle("#3b82f6")}><span aria-hidden="true">🍿</span> Watch My Life</button>
+          <button onClick={() => setCurrentView("LIVE")} style={massiveButtonStyle("#ef4444")}><span aria-hidden="true">📡</span> Go Live (Family Stream)</button>
         </div>
       </div>
     </div>
@@ -211,7 +211,7 @@ export const NexusLegacyApp: React.FC = () => {
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
-        🛑 End Session
+        <span aria-hidden="true">🛑</span> End Session
       </button>
     </div>
   );
@@ -220,7 +220,7 @@ export const NexusLegacyApp: React.FC = () => {
   const renderCreatorMode = () => (
     <div style={{ backgroundColor: "#0f172a", minHeight: "100vh", color: "white", padding: "40px", fontFamily: "sans-serif" }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: "1px solid #334155", paddingBottom: "20px", marginBottom: "40px" }}>
-        <h1 style={{ fontSize: "32px", fontWeight: "bold", color: "#38bdf8" }}>⚡ Studio Edit: {userName}'s Legacy</h1>
+        <h1 style={{ fontSize: "32px", fontWeight: "bold", color: "#38bdf8" }}><span aria-hidden="true">⚡</span> Studio Edit: {userName}'s Legacy</h1>
         <button onClick={() => alert("Exporting to TikTok/Instagram Reels...")} style={{ backgroundColor: "#ec4899", padding: "10px 20px", borderRadius: "8px", fontWeight: "bold", border: "none", cursor: "pointer" }}>Share to Socials</button>
       </div>
 
@@ -349,7 +349,7 @@ export const NexusLegacyApp: React.FC = () => {
           padding: "10px 20px", fontSize: "16px", fontWeight: "bold", cursor: "pointer", backdropFilter: "blur(4px)"
         }}
       >
-        {isCreatorMode ? "Exit Creator Mode" : "⚡ Enter Creator Mode"}
+        {isCreatorMode ? "Exit Creator Mode" : <><span aria-hidden="true">⚡</span> Enter Creator Mode</>}
       </button>
 
       {/* View Router */}
@@ -359,7 +359,7 @@ export const NexusLegacyApp: React.FC = () => {
           {currentView === "DASHBOARD" && renderDashboard()}
           {currentView === "INTERVIEW" && <SeniorFriendlyGeminiUI userId="user_123" />}
           {currentView === "WATCH" && renderWatchGallery()}
-          {currentView === "LIVE" && <div style={{ color: "white", padding: "100px", fontSize: "48px", textAlign: "center" }}>📡 Connecting to Family Livestream...</div>}
+          {currentView === "LIVE" && <div style={{ color: "white", padding: "100px", fontSize: "48px", textAlign: "center" }}><span aria-hidden="true">📡</span> Connecting to Family Livestream...</div>}
           {currentView === "CREATOR_MODE" && renderCreatorMode()}
         </>
       )}

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -114,9 +114,10 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
           {/* Header & Multilingual Toggle */}
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "40px" }}>
               <h1 style={{ color: "#FFD700", fontSize: "48px", fontWeight: "bold", margin: 0 }}>
-                  <span style={{ fontSize: "56px" }}>🎥</span> AI Director
+                  <span style={{ fontSize: "56px" }} aria-hidden="true">🎥</span> AI Director
               </h1>
               <select
+                  aria-label="Select language"
                   value={language}
                   onChange={(e) => setLanguage(e.target.value)}
                   style={{ fontSize: "24px", padding: "10px", backgroundColor: "#005f73", color: "#fff", border: "none", borderRadius: "8px", cursor: "pointer" }}
@@ -150,11 +151,11 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
                   <div style={{ marginTop: "40px", display: "flex", gap: "20px" }}>
                       {!isCalling ? (
                           <button onClick={handleCallToggle} style={{ fontSize: "36px", padding: "20px 60px", backgroundColor: "#22c55e", color: "white", border: "none", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", boxShadow: "0 0 30px rgba(34, 197, 94, 0.6)", transition: "transform 0.2s" }}>
-                              📞 {translations[language].btnCall}
+                              <span aria-hidden="true">📞</span> {translations[language].btnCall}
                           </button>
                       ) : (
                           <button onClick={handleCallToggle} style={{ fontSize: "36px", padding: "20px 60px", backgroundColor: "#ef4444", color: "white", border: "none", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", boxShadow: "0 0 30px rgba(239, 68, 68, 0.6)" }}>
-                              ☎️ {translations[language].btnEnd}
+                              <span aria-hidden="true">☎️</span> {translations[language].btnEnd}
                           </button>
                       )}
                   </div>


### PR DESCRIPTION
## 🎨 Palette: Improve accessibility of emojis in buttons

**💡 What:** 
Wrapped decorative emojis within action buttons in `NEXUS_LEGACY_APP.tsx` and `SeniorFriendlyGeminiUI.tsx` with `<span aria-hidden="true">`. Also added an `aria-label` to the language `<select>` dropdown.

**🎯 Why:** 
Providing an `aria-label` to a button that completely overrides visible text violates WCAG 2.5.3 (Label in Name). Instead of overriding the button text, we should explicitly hide the decorative, un-pronounceable emojis from screen readers so the assistive technology naturally reads the visible button text.

**♿ Accessibility:** 
- Emojis no longer cause screen readers to stumble or read confusing Unicode descriptions alongside the intended button action.
- Ensure language selector is discoverable by screen reader users navigating forms.

---
*PR created automatically by Jules for task [1620932445658902625](https://jules.google.com/task/1620932445658902625) started by @DevAIEngine*