### PR TITLE
🎨 Palette: Wrap decorative emojis and add language select aria-label

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-15 - [Accessibility: Emojis and Text in Buttons]
+**Learning:** When combining emojis and visible text in buttons, do not override the visible text with `aria-label` as it violates WCAG 2.5.3 (Label in Name). Screen readers may fail to announce the visible text.
+**Action:** Wrap decorative emojis in `<span aria-hidden="true">` to hide them from screen readers while preserving the accessible name derived from the visible text.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -114,9 +114,10 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
           {/* Header & Multilingual Toggle */}
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "40px" }}>
               <h1 style={{ color: "#FFD700", fontSize: "48px", fontWeight: "bold", margin: 0 }}>
-                  <span style={{ fontSize: "56px" }}>🎥</span> AI Director
+                  <span style={{ fontSize: "56px" }} aria-hidden="true">🎥</span> AI Director
               </h1>
               <select
+                  aria-label="Select language"
                   value={language}
                   onChange={(e) => setLanguage(e.target.value)}
                   style={{ fontSize: "24px", padding: "10px", backgroundColor: "#005f73", color: "#fff", border: "none", borderRadius: "8px", cursor: "pointer" }}
@@ -150,11 +151,11 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
                   <div style={{ marginTop: "40px", display: "flex", gap: "20px" }}>
                       {!isCalling ? (
                           <button onClick={handleCallToggle} style={{ fontSize: "36px", padding: "20px 60px", backgroundColor: "#22c55e", color: "white", border: "none", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", boxShadow: "0 0 30px rgba(34, 197, 94, 0.6)", transition: "transform 0.2s" }}>
-                              📞 {translations[language].btnCall}
+                              <span aria-hidden="true">📞</span> {translations[language].btnCall}
                           </button>
                       ) : (
                           <button onClick={handleCallToggle} style={{ fontSize: "36px", padding: "20px 60px", backgroundColor: "#ef4444", color: "white", border: "none", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", boxShadow: "0 0 30px rgba(239, 68, 68, 0.6)" }}>
-                              ☎️ {translations[language].btnEnd}
+                              <span aria-hidden="true">☎️</span> {translations[language].btnEnd}
                           </button>
                       )}
                   </div>


### PR DESCRIPTION
💡 What: Wrapped decorative emojis (`📞`, `☎️`, `🎥`) in `<span aria-hidden="true">` and added `aria-label="Select language"` to the language `<select>` dropdown in `frontend/SeniorFriendlyGeminiUI.tsx`.
🎯 Why: To improve screen reader accessibility by hiding decorative elements that might interfere with visible text labels, adhering to WCAG 2.5.3, and ensuring the language dropdown is properly identified by assistive technologies.
♿ Accessibility: Ensures decorative emojis do not override or conflict with visible text labels for screen readers, and provides a clear accessible name for the language selection control.

---
*PR created automatically by Jules for task [3505078213638832202](https://jules.google.com/task/3505078213638832202) started by @DevAIEngine*