### PR TITLE
🛡️ Sentinel: [HIGH] Fix Unhandled Exceptions via JSON Validation in veo-studio/generate-scenes

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Flask `app.run` was hardcoded with `debug=True` and `host='0.0.0.0'`. This exposed the Werkzeug interactive debugger to all network interfaces, allowing arbitrary remote code execution (RCE).
 **Learning:** Hardcoding debug mode on a globally bound host (`0.0.0.0`) is a critical security vulnerability.
 **Prevention:** Always use environment variables (e.g., `FLASK_DEBUG`) to control debug mode, and ensure it defaults to `False` in production or default contexts.
+
+## 2024-03-15 - [Fix unhandled exceptions in veo_generate_scenes]
+**Vulnerability:** The `/veo-studio/generate-scenes` endpoint in `infrastructure/app.py` did not validate incoming JSON. An invalid `scenes` structure or non-numeric `duration` caused Python unhandled exceptions (`TypeError`), leaking error stack traces.
+**Learning:** Even internal API endpoints expecting a specific data structure must sanitize and type-check all incoming JSON. A missing `duration` value or an unexpected type can crash the route and expose the application state.
+**Prevention:** Always validate that `request.json` contains the expected keys, verify they are the correct type, and handle invalid shapes gracefully with a `400 Bad Request` instead of triggering a 500 error.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -119,11 +119,24 @@ def veo_generate():
 @app.route('/veo-studio/generate-scenes', methods=['POST'])
 def veo_generate_scenes():
     data = request.json
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid JSON format"}), 400
+
+    scenes = data.get('scenes', [])
+    if not isinstance(scenes, list):
+        return jsonify({"error": "scenes must be a list"}), 400
+
+    for scene in scenes:
+        if not isinstance(scene, dict):
+            return jsonify({"error": "each scene must be an object"}), 400
+        if 'duration' not in scene or not isinstance(scene['duration'], (int, float)):
+            return jsonify({"error": "each scene must have a numeric duration"}), 400
+
     return jsonify({
         "videoId": str(uuid.uuid4()),
         "videoUrl": f"/static/multi-scene.mp4",
-        "totalDuration": sum(s['duration'] for s in data.get('scenes', [])),
-        "sceneCount": len(data.get('scenes', [])),
+        "totalDuration": sum(s['duration'] for s in scenes),
+        "sceneCount": len(scenes),
         "status": "completed"
     })
 

--- a/test_app_security.py
+++ b/test_app_security.py
@@ -1,0 +1,25 @@
+import pytest
+from infrastructure.app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_generate_scenes_no_json(client):
+    rv = client.post('/veo-studio/generate-scenes', data="not json")
+    assert rv.status_code == 400 or rv.status_code == 415
+
+def test_generate_scenes_invalid_scenes(client):
+    rv = client.post('/veo-studio/generate-scenes', json={"scenes": "not_a_list"})
+    assert rv.status_code == 400
+
+def test_generate_scenes_invalid_duration(client):
+    rv = client.post('/veo-studio/generate-scenes', json={"scenes": [{"duration": "str"}]})
+    assert rv.status_code == 400
+
+def test_generate_scenes_valid(client):
+    rv = client.post('/veo-studio/generate-scenes', json={"scenes": [{"duration": 10}, {"duration": 20.5}]})
+    assert rv.status_code == 200
+    assert rv.json['totalDuration'] == 30.5


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/veo-studio/generate-scenes` endpoint in `infrastructure/app.py` directly unpacked user-controlled input (`data.get('scenes')`) without type validation. If the `scenes` attribute was not a list, or contained invalid entries (missing numeric `duration`), the backend threw an unhandled `TypeError` (e.g., `TypeError: string indices must be integers`), resulting in a 500 error that could leak internal stack traces.
🎯 **Impact:** Exposes the server to denial of service from malformed JSON queries, leaks internal error traces to users, and causes the application to fail insecurely instead of handling errors gracefully.
🔧 **Fix:** Added rigorous input validation in `veo_generate_scenes`. The payload is now verified to be a dictionary, `scenes` is verified as a list, and each `scene` inside is checked to ensure it contains a valid numeric `duration`. Invalid payloads immediately return a `400 Bad Request` instead of triggering Python exceptions.
✅ **Verification:** Ran the full Flask `test_app_security.py` test suite, which ensures that non-JSON data, invalid structure (`{"scenes": "not_a_list"}`), and invalid keys (`{"duration": "str"}`) correctly return `400 Bad Request`. All tests pass.

---
*PR created automatically by Jules for task [3406686556010489690](https://jules.google.com/task/3406686556010489690) started by @DevAIEngine*