### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix unhandled exceptions in /veo-studio/generate-scenes

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Flask `app.run` was hardcoded with `debug=True` and `host='0.0.0.0'`. This exposed the Werkzeug interactive debugger to all network interfaces, allowing arbitrary remote code execution (RCE).
 **Learning:** Hardcoding debug mode on a globally bound host (`0.0.0.0`) is a critical security vulnerability.
 **Prevention:** Always use environment variables (e.g., `FLASK_DEBUG`) to control debug mode, and ensure it defaults to `False` in production or default contexts.
+## 2025-04-05 - [MEDIUM] Fix unhandled exceptions in /veo-studio/generate-scenes
+**Vulnerability:** The `/veo-studio/generate-scenes` endpoint directly accessed keys from `request.json` without verifying if the payload was a dictionary, or if required keys like `scenes` and `duration` existed and were of correct types.
+**Learning:** Unvalidated JSON payloads can cause `TypeError` or `KeyError`, leading to unhandled exceptions and potentially exposing internal server state.
+**Prevention:** Always validate that `request.json` is a dictionary and explicitly check the structure and types of all required nested data before processing.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -118,12 +118,25 @@ def veo_generate():
 
 @app.route('/veo-studio/generate-scenes', methods=['POST'])
 def veo_generate_scenes():
-    data = request.json
+    data = request.json or {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid JSON payload"}), 400
+
+    scenes = data.get('scenes', [])
+    if not isinstance(scenes, list):
+        return jsonify({"error": "'scenes' must be a list"}), 400
+
+    total_duration = 0
+    for s in scenes:
+        if not isinstance(s, dict) or 'duration' not in s or not isinstance(s['duration'], (int, float)):
+            return jsonify({"error": "Each scene must be a dictionary with a numeric 'duration'"}), 400
+        total_duration += s['duration']
+
     return jsonify({
         "videoId": str(uuid.uuid4()),
         "videoUrl": f"/static/multi-scene.mp4",
-        "totalDuration": sum(s['duration'] for s in data.get('scenes', [])),
-        "sceneCount": len(data.get('scenes', [])),
+        "totalDuration": total_duration,
+        "sceneCount": len(scenes),
         "status": "completed"
     })
 


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `/veo-studio/generate-scenes` endpoint directly accessed keys from `request.json` without verifying if the payload was a dictionary, or if required keys like `scenes` and `duration` existed and were of correct types.
🎯 **Impact:** Unvalidated JSON payloads could cause unhandled `TypeError`, `KeyError`, or `AttributeError`, resulting in HTTP 500 server errors. This could potentially leak internal stack traces to users.
🔧 **Fix:** Added validation checks to verify `data` is a `dict`, `scenes` is a `list`, and each scene contains a numeric `duration`. Returns a 400 Bad Request error if validation fails.
✅ **Verification:** Verified that the changes do not break existing test cases and syntactically lint correctly.

---
*PR created automatically by Jules for task [7278341558815144707](https://jules.google.com/task/7278341558815144707) started by @DevAIEngine*