### PR TITLE
🎨 Palette: [Accessibility: Hide decorative emojis from screen readers]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - [Accessibility: Hide decorative emojis from screen readers]
+**Learning:** When improving accessibility for buttons with visible text and decorative emojis, do not override the visible text with `aria-label` as it violates WCAG 2.5.3 (Label in Name).
+**Action:** Wrap the emojis in `<span aria-hidden="true">` to hide them from screen readers while preserving the accessible name.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -114,7 +114,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
           {/* Header & Multilingual Toggle */}
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "40px" }}>
               <h1 style={{ color: "#FFD700", fontSize: "48px", fontWeight: "bold", margin: 0 }}>
-                  <span style={{ fontSize: "56px" }}>🎥</span> AI Director
+                  <span style={{ fontSize: "56px" }} aria-hidden="true">🎥</span> AI Director
               </h1>
               <select
                   value={language}
@@ -150,11 +150,11 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
                   <div style={{ marginTop: "40px", display: "flex", gap: "20px" }}>
                       {!isCalling ? (
                           <button onClick={handleCallToggle} style={{ fontSize: "36px", padding: "20px 60px", backgroundColor: "#22c55e", color: "white", border: "none", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", boxShadow: "0 0 30px rgba(34, 197, 94, 0.6)", transition: "transform 0.2s" }}>
-                              📞 {translations[language].btnCall}
+                              <span aria-hidden="true">📞</span> {translations[language].btnCall}
                           </button>
                       ) : (
                           <button onClick={handleCallToggle} style={{ fontSize: "36px", padding: "20px 60px", backgroundColor: "#ef4444", color: "white", border: "none", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", boxShadow: "0 0 30px rgba(239, 68, 68, 0.6)" }}>
-                              ☎️ {translations[language].btnEnd}
+                              <span aria-hidden="true">☎️</span> {translations[language].btnEnd}
                           </button>
                       )}
                   </div>


### PR DESCRIPTION
💡 **What:** Added `aria-hidden="true"` to decorative emojis in `SeniorFriendlyGeminiUI.tsx` by wrapping them in `<span>` tags.

🎯 **Why:** To improve screen reader accessibility. When buttons have visible text (e.g. "ANSWER CALL") alongside emojis, screen readers often read the emoji description, adding unnecessary noise. Masking the emoji using `aria-hidden="true"` maintains the visual aesthetic while delivering a clean, accurate voice readout of the button's purpose without violating WCAG 2.5.3 (Label in Name).

📸 **Before/After:** No visual changes (verified via Playwright UI screenshot).

♿ **Accessibility:** Fixes screen reader redundancy on the primary action buttons and header.

---
*PR created automatically by Jules for task [6925077632579113819](https://jules.google.com/task/6925077632579113819) started by @DevAIEngine*