### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix JSON injection in bash script

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Flask `app.run` was hardcoded with `debug=True` and `host='0.0.0.0'`. This exposed the Werkzeug interactive debugger to all network interfaces, allowing arbitrary remote code execution (RCE).
 **Learning:** Hardcoding debug mode on a globally bound host (`0.0.0.0`) is a critical security vulnerability.
 **Prevention:** Always use environment variables (e.g., `FLASK_DEBUG`) to control debug mode, and ensure it defaults to `False` in production or default contexts.
+## 2024-04-07 - [Fix JSON injection in make_episode.sh payload]
+**Vulnerability:** Bash script passed unsanitized arguments directly into a JSON string payload for a curl command via string concatenation. This could allow JSON injection or command execution.
+**Learning:** Never build JSON using bash string interpolation with user input.
+**Prevention:** Always use `jq -n --arg` or similar safe parameterization when constructing JSON payloads in shell scripts.

--- a/make_episode.sh
+++ b/make_episode.sh
@@ -19,13 +19,16 @@ fi
 echo "🚀 Connecting to Cloud Run Orchestrator (us-west2)..."
 # In production, this curl triggers the FastAPI OrchestrationAssemblyLine
 # POST /api/orchestration/publish
+
+JSON_PAYLOAD=$(jq -n --arg project_id "$PROJECT_ID" --arg script_url "$SCRIPT_URL" --arg mode "FULL_CASCADE" '{
+  "project_id": $project_id,
+  "script_url": $script_url,
+  "mode": $mode
+}')
+
 curl -X POST https://guce-engine-0446134261-uc.a.run.app/api/orchestration/publish \
   -H "Content-Type: application/json" \
-  -d '{
-    "project_id": "'$PROJECT_ID'",
-    "script_url": "'$SCRIPT_URL'",
-    "mode": "FULL_CASCADE"
-  }'
+  -d "$JSON_PAYLOAD"
 
 echo ""
 echo "✅ Episode assembly initiated! The AI Swarm is currently:"


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix JSON injection

🚨 Severity: CRITICAL
💡 Vulnerability: The `make_episode.sh` bash script constructed a JSON payload for a curl command using raw string interpolation `'{ "project_id": "'$PROJECT_ID'", "script_url": "'$SCRIPT_URL'" }'`. If `$SCRIPT_URL` contained quotes, it could escape the JSON structure and allow injection or command execution.
🎯 Impact: This could allow an attacker to inject arbitrary JSON keys or values, and depending on the execution context, potentially execute arbitrary commands.
🔧 Fix: Replaced string concatenation with `jq -n --arg`, which safely parameterizes the variables and properly escapes any special characters before rendering the JSON string.
✅ Verification: Ensure the `jq` dependency is available, run the script, and observe that the curl payload is valid JSON even if the inputs contain quotes.

Recorded this critical learning in `.Jules/sentinel.md`.

---
*PR created automatically by Jules for task [13106138331447133316](https://jules.google.com/task/13106138331447133316) started by @DevAIEngine*