### PR TITLE
🎨 Palette: Hide decorative emojis from screen readers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Hide decorative emojis from screen readers
+**Learning:** When improving accessibility for buttons with visible text and decorative emojis, overriding the visible text with `aria-label` violates WCAG 2.5.3 (Label in Name).
+**Action:** Wrap the emojis in `<span aria-hidden="true">` to hide them from screen readers while preserving the accessible name.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -167,10 +167,10 @@ export const NexusLegacyApp: React.FC = () => {
         <p style={{ fontSize: "32px", color: themeStyles.textColor, marginBottom: "60px" }}>What story shall we tell today?</p>
 
         <div style={{ display: "flex", flexDirection: "column", gap: "30px" }}>
-          <button onClick={() => setCurrentView("INTERVIEW")} style={massiveButtonStyle("#22c55e")}>🎙️ Tell a Story (Video Call)</button>
-          <button onClick={() => setIsVoiceOnlyMode(true)} style={massiveButtonStyle("#8b5cf6")}>🔮 Tell a Story (Voice Only)</button>
-          <button onClick={() => setCurrentView("WATCH")} style={massiveButtonStyle("#3b82f6")}>🍿 Watch My Life</button>
-          <button onClick={() => setCurrentView("LIVE")} style={massiveButtonStyle("#ef4444")}>📡 Go Live (Family Stream)</button>
+          <button onClick={() => setCurrentView("INTERVIEW")} style={massiveButtonStyle("#22c55e")}><span aria-hidden="true">🎙️</span> Tell a Story (Video Call)</button>
+          <button onClick={() => setIsVoiceOnlyMode(true)} style={massiveButtonStyle("#8b5cf6")}><span aria-hidden="true">🔮</span> Tell a Story (Voice Only)</button>
+          <button onClick={() => setCurrentView("WATCH")} style={massiveButtonStyle("#3b82f6")}><span aria-hidden="true">🍿</span> Watch My Life</button>
+          <button onClick={() => setCurrentView("LIVE")} style={massiveButtonStyle("#ef4444")}><span aria-hidden="true">📡</span> Go Live (Family Stream)</button>
         </div>
       </div>
     </div>
@@ -211,7 +211,7 @@ export const NexusLegacyApp: React.FC = () => {
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
-        🛑 End Session
+        <span aria-hidden="true">🛑</span> End Session
       </button>
     </div>
   );
@@ -220,7 +220,7 @@ export const NexusLegacyApp: React.FC = () => {
   const renderCreatorMode = () => (
     <div style={{ backgroundColor: "#0f172a", minHeight: "100vh", color: "white", padding: "40px", fontFamily: "sans-serif" }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: "1px solid #334155", paddingBottom: "20px", marginBottom: "40px" }}>
-        <h1 style={{ fontSize: "32px", fontWeight: "bold", color: "#38bdf8" }}>⚡ Studio Edit: {userName}'s Legacy</h1>
+        <h1 style={{ fontSize: "32px", fontWeight: "bold", color: "#38bdf8" }}><span aria-hidden="true">⚡</span> Studio Edit: {userName}'s Legacy</h1>
         <button onClick={() => alert("Exporting to TikTok/Instagram Reels...")} style={{ backgroundColor: "#ec4899", padding: "10px 20px", borderRadius: "8px", fontWeight: "bold", border: "none", cursor: "pointer" }}>Share to Socials</button>
       </div>
 
@@ -313,7 +313,7 @@ export const NexusLegacyApp: React.FC = () => {
 
             {/* Play Button Icon overlay */}
             <div style={{ position: "absolute", top: "40px", right: "40px", zIndex: 1, backgroundColor: "rgba(255,215,0,0.8)", borderRadius: "50%", width: "80px", height: "80px", display: "flex", alignItems: "center", justifyContent: "center" }}>
-              <span style={{ fontSize: "36px", marginLeft: "10px" }}>▶</span>
+              <span style={{ fontSize: "36px", marginLeft: "10px" }} aria-hidden="true">▶</span>
             </div>
           </button>
         ))}
@@ -349,7 +349,7 @@ export const NexusLegacyApp: React.FC = () => {
           padding: "10px 20px", fontSize: "16px", fontWeight: "bold", cursor: "pointer", backdropFilter: "blur(4px)"
         }}
       >
-        {isCreatorMode ? "Exit Creator Mode" : "⚡ Enter Creator Mode"}
+        {isCreatorMode ? "Exit Creator Mode" : <><span aria-hidden="true">⚡</span> Enter Creator Mode</>}
       </button>
 
       {/* View Router */}
@@ -359,7 +359,7 @@ export const NexusLegacyApp: React.FC = () => {
           {currentView === "DASHBOARD" && renderDashboard()}
           {currentView === "INTERVIEW" && <SeniorFriendlyGeminiUI userId="user_123" />}
           {currentView === "WATCH" && renderWatchGallery()}
-          {currentView === "LIVE" && <div style={{ color: "white", padding: "100px", fontSize: "48px", textAlign: "center" }}>📡 Connecting to Family Livestream...</div>}
+          {currentView === "LIVE" && <div style={{ color: "white", padding: "100px", fontSize: "48px", textAlign: "center" }}><span aria-hidden="true">📡</span> Connecting to Family Livestream...</div>}
           {currentView === "CREATOR_MODE" && renderCreatorMode()}
         </>
       )}

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -114,7 +114,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
           {/* Header & Multilingual Toggle */}
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "40px" }}>
               <h1 style={{ color: "#FFD700", fontSize: "48px", fontWeight: "bold", margin: 0 }}>
-                  <span style={{ fontSize: "56px" }}>🎥</span> AI Director
+                  <span style={{ fontSize: "56px" }} aria-hidden="true">🎥</span> AI Director
               </h1>
               <select
                   value={language}
@@ -150,11 +150,11 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
                   <div style={{ marginTop: "40px", display: "flex", gap: "20px" }}>
                       {!isCalling ? (
                           <button onClick={handleCallToggle} style={{ fontSize: "36px", padding: "20px 60px", backgroundColor: "#22c55e", color: "white", border: "none", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", boxShadow: "0 0 30px rgba(34, 197, 94, 0.6)", transition: "transform 0.2s" }}>
-                              📞 {translations[language].btnCall}
+                              <span aria-hidden="true">📞</span> {translations[language].btnCall}
                           </button>
                       ) : (
                           <button onClick={handleCallToggle} style={{ fontSize: "36px", padding: "20px 60px", backgroundColor: "#ef4444", color: "white", border: "none", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", boxShadow: "0 0 30px rgba(239, 68, 68, 0.6)" }}>
-                              ☎️ {translations[language].btnEnd}
+                              <span aria-hidden="true">☎️</span> {translations[language].btnEnd}
                           </button>
                       )}
                   </div>


### PR DESCRIPTION
Wrapped decorative emojis in `<span aria-hidden="true">` across `frontend/SeniorFriendlyGeminiUI.tsx` and `frontend/NEXUS_LEGACY_APP.tsx` to hide them from screen readers while preserving the accessible name. This avoids overriding visible text with `aria-label`, which violates WCAG 2.5.3 (Label in Name).
Added corresponding entry to `.Jules/palette.md` noting this finding.

---
*PR created automatically by Jules for task [187391958796068516](https://jules.google.com/task/187391958796068516) started by @DevAIEngine*