### PR TITLE
🛡️ Sentinel: [HIGH] Fix JSON injection in make_episode.sh payload generation

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Flask `app.run` was hardcoded with `debug=True` and `host='0.0.0.0'`. This exposed the Werkzeug interactive debugger to all network interfaces, allowing arbitrary remote code execution (RCE).
 **Learning:** Hardcoding debug mode on a globally bound host (`0.0.0.0`) is a critical security vulnerability.
 **Prevention:** Always use environment variables (e.g., `FLASK_DEBUG`) to control debug mode, and ensure it defaults to `False` in production or default contexts.
+## 2024-04-08 - [Fix JSON/Command Injection in curl payload]
+**Vulnerability:** Shell scripts using raw string concatenation (e.g., `'{"script_url": "'$SCRIPT_URL'"}'`) in `curl` payloads are vulnerable to JSON injection. If user input contains quotes, the JSON structure breaks or can be maliciously manipulated.
+**Learning:** Never use string concatenation to build JSON in bash scripts when handling arbitrary input.
+**Prevention:** Always use `jq -n --arg` (e.g., `jq -n --arg url "$SCRIPT_URL" '{"url": $url}'`) to safely escape user input and generate valid JSON.

--- a/make_episode.sh
+++ b/make_episode.sh
@@ -19,13 +19,12 @@ fi
 echo "🚀 Connecting to Cloud Run Orchestrator (us-west2)..."
 # In production, this curl triggers the FastAPI OrchestrationAssemblyLine
 # POST /api/orchestration/publish
+# 🛡️ Sentinel: Safely construct JSON payload using jq to prevent JSON/command injection
+PAYLOAD=$(jq -n --arg pid "$PROJECT_ID" --arg url "$SCRIPT_URL" --arg mode "FULL_CASCADE" '{"project_id": $pid, "script_url": $url, "mode": $mode}')
+
 curl -X POST https://guce-engine-0446134261-uc.a.run.app/api/orchestration/publish \
   -H "Content-Type: application/json" \
-  -d '{
-    "project_id": "'$PROJECT_ID'",
-    "script_url": "'$SCRIPT_URL'",
-    "mode": "FULL_CASCADE"
-  }'
+  -d "$PAYLOAD"
 
 echo ""
 echo "✅ Episode assembly initiated! The AI Swarm is currently:"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `make_episode.sh` constructed the JSON payload for its `curl` request using raw bash string interpolation (e.g., `"script_url": "'$SCRIPT_URL'"`). If a user passed a script URL containing quotes or other shell metacharacters, it would break the JSON structure or allow arbitrary JSON/command injection, potentially manipulating the API request to the backend orchestrator.
🎯 **Impact:** An attacker or misconfigured script could inject malicious JSON parameters or potentially execute commands depending on how the backend evaluates the payload, bypassing intended pipeline logic.
🔧 **Fix:** Replaced raw string concatenation with `jq -n --arg`, which safely constructs the JSON object by escaping any user-provided string input automatically.
✅ **Verification:** Verified syntax with `bash -n` and ran tests using `pytest test_app.py` and `flake8` to ensure the codebase remains structurally sound. Also recorded the learning in `.Jules/sentinel.md`.

---
*PR created automatically by Jules for task [8649090369006828981](https://jules.google.com/task/8649090369006828981) started by @DevAIEngine*