### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing auth on /api/publish

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Flask `app.run` was hardcoded with `debug=True` and `host='0.0.0.0'`. This exposed the Werkzeug interactive debugger to all network interfaces, allowing arbitrary remote code execution (RCE).
 **Learning:** Hardcoding debug mode on a globally bound host (`0.0.0.0`) is a critical security vulnerability.
 **Prevention:** Always use environment variables (e.g., `FLASK_DEBUG`) to control debug mode, and ensure it defaults to `False` in production or default contexts.
+
+## 2026-04-15 - Missing Authentication on Publish Endpoints
+**Vulnerability:** Public API endpoints in `infrastructure/app.py` were fully exposed without authentication, allowing unauthorized users to trigger workflows and invoke external APIs (e.g. Gemini, Vertex AI).
+**Learning:** Endpoints mapped to high-cost or sensitive generative operations must enforce app-level authorization, regardless of Cloud Run's basic IAM protections.
+**Prevention:** Always implement an authentication decorator (like `require_api_key`) and use a secure comparison like `hmac.compare_digest` to protect public application-level endpoints.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -1,6 +1,8 @@
 from flask import Flask, request, jsonify
 from google.cloud import aiplatform
 from googleapiclient.discovery import build
+from functools import wraps
+import hmac
 import os
 import uuid
 import datetime
@@ -16,7 +18,21 @@ def get_drive_service():
 def get_sheets_service():
     return build('sheets', 'v4')
 
+
+def require_api_key(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        api_key = os.environ.get('GUCE_API_KEY')
+        if not api_key:
+            return jsonify({'error': 'Internal server error: API key not configured'}), 500
+        provided_key = request.headers.get('X-API-Key')
+        if not provided_key or not hmac.compare_digest(provided_key, api_key):
+            return jsonify({'error': 'Unauthorized'}), 401
+        return f(*args, **kwargs)
+    return decorated_function
+
 @app.route('/api/publish', methods=['POST'])
+@require_api_key
 def publish():
     data = request.json or {}
     project_id = str(uuid.uuid4())


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Public API endpoint `/api/publish` in `infrastructure/app.py` was fully exposed without authentication, allowing unauthorized users to trigger workflows and invoke external APIs (e.g. Gemini, Vertex AI).
🎯 Impact: An attacker could trigger unbounded, high-cost external API calls and resource creation on the server side, potentially leading to financial losses or resource exhaustion.
🔧 Fix: Implemented an authentication decorator (`require_api_key`) that verifies the `X-API-Key` header against the `GUCE_API_KEY` environment variable using a secure `hmac.compare_digest` to mitigate timing attacks.
✅ Verification: Tested via pytest confirming 401 Unauthorized for requests lacking valid keys and expected propagation for valid ones. Checked using standard linters and existing test suite.

---
*PR created automatically by Jules for task [8827202180487892199](https://jules.google.com/task/8827202180487892199) started by @DevAIEngine*