### PR TITLE
🎨 Palette: Improve accessibility for language selector and decorative imagery

### DIFF
--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -154,6 +154,8 @@ export const NexusLegacyApp: React.FC = () => {
     }}>
       {/* Cinematic Ken Burns Background */}
       <img src={themeStyles.bgUrl}
+           alt=""
+           aria-hidden="true"
            className="documentary-image"
            style={{ position: "absolute", zIndex: 0, width: "100%", height: "100%", objectFit: "cover" }}
       />

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -114,9 +114,10 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
           {/* Header & Multilingual Toggle */}
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "40px" }}>
               <h1 style={{ color: "#FFD700", fontSize: "48px", fontWeight: "bold", margin: 0 }}>
-                  <span style={{ fontSize: "56px" }}>🎥</span> AI Director
+                  <span style={{ fontSize: "56px" }} aria-hidden="true">🎥</span> AI Director
               </h1>
               <select
+                  aria-label="Select preferred language"
                   value={language}
                   onChange={(e) => setLanguage(e.target.value)}
                   style={{ fontSize: "24px", padding: "10px", backgroundColor: "#005f73", color: "#fff", border: "none", borderRadius: "8px", cursor: "pointer" }}


### PR DESCRIPTION
🎨 Palette: [UX improvement]
💡 What: Added `aria-label` to the language `<select>` dropdown, and properly hid decorative elements (the 🎥 emoji and background images) from the accessibility tree using `aria-hidden="true"` and empty `alt=""` text.
🎯 Why: Without an `aria-label`, screen reader users tabbing through the `SeniorFriendlyGeminiUI` would not understand the purpose of the language `<select>` dropdown. Additionally, decorative emojis and background images cause unnecessary clutter when read aloud by assistive technology, breaking the immersion of the UI.
📸 Before/After: Visuals remain unchanged, but the DOM now semantically supports screen readers.
♿ Accessibility: Improved keyboard navigation clarity and reduced screen reader noise for visually impaired users interacting with the "Cinematic Legacy" Engine.

---
*PR created automatically by Jules for task [10243103285035088772](https://jules.google.com/task/10243103285035088772) started by @DevAIEngine*