### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Unauthenticated API Endpoints & Command Injection

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Flask `app.run` was hardcoded with `debug=True` and `host='0.0.0.0'`. This exposed the Werkzeug interactive debugger to all network interfaces, allowing arbitrary remote code execution (RCE).
 **Learning:** Hardcoding debug mode on a globally bound host (`0.0.0.0`) is a critical security vulnerability.
 **Prevention:** Always use environment variables (e.g., `FLASK_DEBUG`) to control debug mode, and ensure it defaults to `False` in production or default contexts.
+## 2024-05-20 - [Fix Unauthenticated API Endpoints & Command Injection]
+**Vulnerability:** Core publishing endpoints lacked authentication, and make_episode.sh constructed JSON insecurely, allowing injection.
+**Learning:** Application-level authentication is required for public endpoints, and shell scripts must use safe JSON construction (e.g., jq).
+**Prevention:** Always use require_api_key decorators and safe data handling techniques in shell scripts.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -2,6 +2,8 @@ from flask import Flask, request, jsonify
 from google.cloud import aiplatform
 from googleapiclient.discovery import build
 import os
+import hmac
+from functools import wraps
 import uuid
 import datetime
 
@@ -16,7 +18,19 @@ def get_drive_service():
 def get_sheets_service():
     return build('sheets', 'v4')
 
+
+def require_api_key(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        api_key = os.environ.get('GUCE_API_KEY')
+        request_key = request.headers.get('X-API-Key')
+        if not api_key or not request_key or not hmac.compare_digest(api_key, request_key):
+            return jsonify({'error': 'Unauthorized'}), 401
+        return f(*args, **kwargs)
+    return decorated_function
+
 @app.route('/api/publish', methods=['POST'])
+@require_api_key
 def publish():
     data = request.json or {}
     project_id = str(uuid.uuid4())
@@ -77,6 +91,7 @@ def publish():
         return jsonify({'error': str(e)}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
+@require_api_key
 def orchestration_publish():
     """
     Wires all modules sequentially:

--- a/make_episode.sh
+++ b/make_episode.sh
@@ -19,13 +19,15 @@ fi
 echo "🚀 Connecting to Cloud Run Orchestrator (us-west2)..."
 # In production, this curl triggers the FastAPI OrchestrationAssemblyLine
 # POST /api/orchestration/publish
+PAYLOAD=$(jq -n \
+  --arg pid "$PROJECT_ID" \
+  --arg url "$SCRIPT_URL" \
+  '{project_id: $pid, script_url: $url, mode: "FULL_CASCADE"}')
+
 curl -X POST https://guce-engine-0446134261-uc.a.run.app/api/orchestration/publish \
   -H "Content-Type: application/json" \
-  -d '{
-    "project_id": "'$PROJECT_ID'",
-    "script_url": "'$SCRIPT_URL'",
-    "mode": "FULL_CASCADE"
-  }'
+  -H "X-API-Key: ${GUCE_API_KEY}" \
+  -d "$PAYLOAD"
 
 echo ""
 echo "✅ Episode assembly initiated! The AI Swarm is currently:"


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The core publishing API endpoints (`/api/publish` and `/api/orchestration/publish`) lacked application-level authentication. Additionally, the `make_episode.sh` script constructed JSON payloads via string concatenation with shell variables, leaving it vulnerable to command injection.
🎯 **Impact:** Unauthorized users could trigger expensive Cloud Run and Vertex AI pipelines. Command injection could allow an attacker to execute arbitrary code.
🔧 **Fix:** Implemented a `require_api_key` decorator using `hmac.compare_digest` in `infrastructure/app.py`. Refactored `make_episode.sh` to use `jq` with parameterized inputs and passed the correct `X-API-Key` header.
✅ **Verification:** Tested the API endpoints manually with and without an API key. Re-ran the automated test suite and linter. Verified the bash script behavior. Recorded the learnings in `.Jules/sentinel.md`.

---
*PR created automatically by Jules for task [7790191828151138770](https://jules.google.com/task/7790191828151138770) started by @DevAIEngine*