### PR TITLE
🎨 Palette: Add accessibility attributes to decorative background image

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-20 - Decorative Image Screen Reader Noise
+**Learning:** Decorative background `<img>` tags without `alt` or `aria-hidden` attributes cause significant screen reader noise in cinematic applications.
+**Action:** Always add `alt=""` and `aria-hidden="true"` to background images that provide no semantic value to the document.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -153,7 +153,7 @@ export const NexusLegacyApp: React.FC = () => {
       position: "relative", overflow: "hidden", fontFamily: themeStyles.fontFamily
     }}>
       {/* Cinematic Ken Burns Background */}
-      <img src={themeStyles.bgUrl}
+      <img src={themeStyles.bgUrl} alt="" aria-hidden="true"
            className="documentary-image"
            style={{ position: "absolute", zIndex: 0, width: "100%", height: "100%", objectFit: "cover" }}
       />


### PR DESCRIPTION
Added `alt=""` and `aria-hidden="true"` to the purely decorative Ken Burns background image in `frontend/NEXUS_LEGACY_APP.tsx` to prevent screen readers from reading out the image URL. Also updated the `.Jules/palette.md` journal with a critical learning regarding this UX enhancement.

---
*PR created automatically by Jules for task [15007799574534023425](https://jules.google.com/task/15007799574534023425) started by @DevAIEngine*