### PR TITLE
🛡️ Sentinel: [CRITICAL] Add API key authentication to public endpoints

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Flask `app.run` was hardcoded with `debug=True` and `host='0.0.0.0'`. This exposed the Werkzeug interactive debugger to all network interfaces, allowing arbitrary remote code execution (RCE).
 **Learning:** Hardcoding debug mode on a globally bound host (`0.0.0.0`) is a critical security vulnerability.
 **Prevention:** Always use environment variables (e.g., `FLASK_DEBUG`) to control debug mode, and ensure it defaults to `False` in production or default contexts.
+
+## 2024-05-18 - [Missing API Key Authentication on Public Endpoints]
+**Vulnerability:** Public Flask endpoints (/api/publish, /api/orchestration/publish) lacked application-level authentication, relying solely on Cloud Run ADC.
+**Learning:** Cloud Run ADC does not protect public-facing application routes from unauthenticated HTTP requests.
+**Prevention:** Always implement application-level authentication (e.g., X-API-Key with secure hmac validation) for sensitive endpoints exposed to the public internet.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -1,9 +1,28 @@
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, abort
 from google.cloud import aiplatform
 from googleapiclient.discovery import build
 import os
 import uuid
 import datetime
+import hmac
+import functools
+
+def require_api_key(f):
+    @functools.wraps(f)
+    def decorated_function(*args, **kwargs):
+        expected_api_key = os.environ.get('GUCE_API_KEY')
+        if not expected_api_key:
+            return jsonify({"error": "Internal Server Error: GUCE_API_KEY not configured"}), 500
+
+        api_key = request.headers.get('X-API-Key')
+        if not api_key:
+            return jsonify({"error": "Unauthorized"}), 401
+
+        if not hmac.compare_digest(api_key, expected_api_key):
+            return jsonify({"error": "Unauthorized"}), 401
+
+        return f(*args, **kwargs)
+    return decorated_function
 
 app = Flask(__name__)
 
@@ -17,6 +36,7 @@ def get_sheets_service():
     return build('sheets', 'v4')
 
 @app.route('/api/publish', methods=['POST'])
+@require_api_key
 def publish():
     data = request.json or {}
     project_id = str(uuid.uuid4())
@@ -77,6 +97,7 @@ def publish():
         return jsonify({'error': str(e)}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
+@require_api_key
 def orchestration_publish():
     """
     Wires all modules sequentially:

--- a/make_episode.sh
+++ b/make_episode.sh
@@ -21,6 +21,7 @@ echo "🚀 Connecting to Cloud Run Orchestrator (us-west2)..."
 # POST /api/orchestration/publish
 curl -X POST https://guce-engine-0446134261-uc.a.run.app/api/orchestration/publish \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: $GUCE_API_KEY" \
   -d '{
     "project_id": "'$PROJECT_ID'",
     "script_url": "'$SCRIPT_URL'",


### PR DESCRIPTION
🛡️ **Vulnerability:** Public Flask endpoints (`/api/publish`, `/api/orchestration/publish`) lacked application-level authentication, relying solely on Cloud Run ADC which does not protect public-facing routes from unauthenticated external requests.
🎯 **Impact:** Unauthorized actors could trigger expensive orchestration pipelines and backend processes, leading to resource exhaustion, cloud billing spikes, and potential data manipulation.
🔧 **Fix:** Implemented a `@require_api_key` decorator in `infrastructure/app.py` that validates the `X-API-Key` header against the `GUCE_API_KEY` environment variable. Crucially, it uses `hmac.compare_digest()` to prevent timing attacks. Also updated `make_episode.sh` to pass the correct header.
✅ **Verification:** Ran `pytest test_app.py`, `flake8`, and `make test`. All checks pass. Recorded learning in `.Jules/sentinel.md`.

---
*PR created automatically by Jules for task [11429952079814293260](https://jules.google.com/task/11429952079814293260) started by @DevAIEngine*