### PR TITLE
🛡️ Sentinel: [CRITICAL] Add authentication to capture stream endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2026-03-18 - Unpinned GitHub Action Dependency
- **Vulnerability:** Unpinned GitHub Action Dependency
- **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
- **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+## 2024-04-24 - [Missing Authentication on WebSocket Initializer]
+**Vulnerability:** The `/api/v1/capture/stream` endpoint, which acts as the core entrypoint for the "Cell Phone First UI" to initialize a WebSocket and trigger Gemini Live, lacked any form of authentication or authorization checks.
+**Learning:** This architectural gap could allow unauthenticated users to initiate costly background tasks (like Gemini Live streaming) resulting in potential Denial of Wallet (DoW) and unauthorized access to the core engine's processing capabilities.
+**Prevention:** Always secure public-facing endpoints that trigger heavy asynchronous tasks or downstream paid API calls. Ensure `fastapi.security.HTTPBearer` and `Depends` are configured on all entrypoints to the Sovereign Assembly Pipeline.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,10 @@
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends, Security
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel
 import uuid
 import logging
+import os
+import hmac
 
 # Configure Logging for Epistemic Stability
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - [%(levelname)s] - %(message)s")
@@ -23,8 +26,23 @@ class ProjectManifest(BaseModel):
     language: str = "en"
     scenes: list = []
 
+security = HTTPBearer()
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Security(security)):
+    guce_api_key = os.environ.get("GUCE_API_KEY")
+    if not guce_api_key:
+        logger.error("GUCE_API_KEY environment variable is missing. Failing securely.")
+        raise HTTPException(status_code=500, detail="Internal Server Error: Missing Configuration")
+
+    # Use hmac.compare_digest to prevent timing attacks
+    if not hmac.compare_digest(credentials.credentials, guce_api_key):
+        logger.warning("Invalid API Key provided to secure endpoint.")
+        raise HTTPException(status_code=401, detail="Invalid API Key")
+
+    return credentials.credentials
+
 @app.post("/api/v1/capture/stream", response_model=ProjectManifest)
-async def start_capture_stream(user_id: str, background_tasks: BackgroundTasks):
+async def start_capture_stream(user_id: str, background_tasks: BackgroundTasks, token: str = Depends(get_current_user)):
     """
     Entrypoint for the Cell Phone First UI.
     Initializes a live WebSocket/Stream connection for A-Roll and Gemini Live Scene Decomposition.

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,68 @@
+import pytest
+from fastapi.testclient import TestClient
+import os
+import sys
+
+# Required to mock dependencies before importing the app
+with pytest.MonkeyPatch.context() as m:
+    pass
+
+from backend.main import app
+
+client = TestClient(app)
+
+def test_start_capture_stream_valid_token(monkeypatch):
+    """Test that a valid token allows access to the stream endpoint."""
+    valid_token = "super_secret_token_123"
+    monkeypatch.setenv("GUCE_API_KEY", valid_token)
+
+    response = client.post(
+        "/api/v1/capture/stream",
+        params={"user_id": "test_user"},
+        headers={"Authorization": f"Bearer {valid_token}"}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["user_id"] == "test_user"
+    assert response.json()["status"] == "STREAMING"
+
+def test_start_capture_stream_invalid_token(monkeypatch):
+    """Test that an invalid token returns 401 Unauthorized."""
+    valid_token = "super_secret_token_123"
+    monkeypatch.setenv("GUCE_API_KEY", valid_token)
+
+    response = client.post(
+        "/api/v1/capture/stream",
+        params={"user_id": "test_user"},
+        headers={"Authorization": "Bearer wrong_token"}
+    )
+
+    assert response.status_code == 401
+    assert "Invalid API Key" in response.json()["detail"]
+
+def test_start_capture_stream_missing_token(monkeypatch):
+    """Test that a missing Authorization header returns 403 Forbidden (from HTTPBearer)."""
+    valid_token = "super_secret_token_123"
+    monkeypatch.setenv("GUCE_API_KEY", valid_token)
+
+    response = client.post(
+        "/api/v1/capture/stream",
+        params={"user_id": "test_user"}
+    )
+
+    # fastapi HTTPBearer returns 403 if it is missing
+    assert response.status_code in [401, 403]
+
+def test_start_capture_stream_missing_env_var(monkeypatch):
+    """Test that if GUCE_API_KEY is not set, the endpoint fails securely with 500."""
+    # Ensure GUCE_API_KEY is not in the environment
+    monkeypatch.delenv("GUCE_API_KEY", raising=False)
+
+    response = client.post(
+        "/api/v1/capture/stream",
+        params={"user_id": "test_user"},
+        headers={"Authorization": "Bearer some_token"}
+    )
+
+    assert response.status_code == 500
+    assert "Internal Server Error" in response.json()["detail"]


### PR DESCRIPTION
## 🛡️ Sentinel: [CRITICAL] Add authentication to capture stream endpoint

### 🚨 Severity: CRITICAL
### 💡 Vulnerability:
The `/api/v1/capture/stream` endpoint in `backend/main.py` lacked any form of authentication or authorization. This endpoint serves as the primary entrypoint for the Cell Phone First UI and triggers heavy processing via Gemini Live. 
### 🎯 Impact:
Unauthenticated users could easily trigger backend processes, leading to resource exhaustion or a Denial of Wallet (DoW) by spamming the endpoint and spinning up WebSocket/Gemini Live resources.
### 🔧 Fix:
- Implemented a `get_current_user` dependency using `fastapi.security.HTTPBearer`.
- Used `os.environ.get("GUCE_API_KEY")` to securely fetch the required key.
- Ensured the application fails securely (returns HTTP 500) if the `GUCE_API_KEY` is not present in the environment.
- Used `hmac.compare_digest` to prevent timing attacks when comparing the provided token.
- Applied `Depends(get_current_user)` to the `start_capture_stream` endpoint.
- Added a full test suite in `backend/tests/test_security.py` using `pytest` and `monkeypatch`.

### ✅ Verification:
- Tests run and pass: `PYTHONPATH=. python3 -m pytest backend/tests/test_security.py`
- Code lints correctly: `flake8 backend/ --count --select=E9,F63,F7,F82 --show-source --statistics`

---
*PR created automatically by Jules for task [17038733023846464547](https://jules.google.com/task/17038733023846464547) started by @DevAIEngine*