### PR TITLE
🎨 Palette: Improve form accessibility in Director Documentary template

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-04-29 - [Form Accessibility in HTML Templates]
+**Learning:** Native HTML forms without explicit `<label for="...">` mapping and missing `:focus-visible` styles on interactive elements (buttons, inputs) create significant barriers for keyboard and screen-reader users, even when using utility classes like Tailwind.
+**Action:** Always map labels using the `for` attribute to the input's `id`, and explicitly define `focus-visible:ring-2 focus-visible:ring-blue-500 outline-none` to ensure clear, accessible focus states across all interactive elements.

--- a/frontend/templates/accounts/director_documentary.html
+++ b/frontend/templates/accounts/director_documentary.html
@@ -17,7 +17,7 @@
     <div class="max-w-4xl mx-auto mt-10 p-6">
         <div class="flex justify-between items-center mb-8">
             <h1 class="text-3xl font-bold text-blue-600">Director Jules: Documentary Production</h1>
-            <button onclick="document.body.classList.toggle('dark-mode')" class="text-sm font-semibold text-gray-500 hover:text-blue-500">Toggle Theme</button>
+            <button onclick="document.body.classList.toggle('dark-mode')" class="text-sm font-semibold text-gray-500 hover:text-blue-500 focus-visible:ring-2 focus-visible:ring-blue-500 rounded outline-none">Toggle Theme</button>
         </div>
 
         <div class="card">
@@ -26,15 +26,15 @@
 
             <div class="space-y-4">
                 <div>
-                    <label class="block text-sm font-medium mb-1">Breaking News Topic</label>
-                    <input type="text" id="topic" value="Aerospace Engineering History" class="w-full border rounded p-2 text-gray-900">
+                    <label for="topic" class="block text-sm font-medium mb-1">Breaking News Topic</label>
+                    <input type="text" id="topic" value="Aerospace Engineering History" class="w-full border rounded p-2 text-gray-900 focus-visible:ring-2 focus-visible:ring-blue-500 outline-none">
                 </div>
                 <div>
-                    <label class="block text-sm font-medium mb-1">Requested Fragments (Max 150)</label>
-                    <input type="number" id="fragments" value="150" class="w-full border rounded p-2 text-gray-900">
+                    <label for="fragments" class="block text-sm font-medium mb-1">Requested Fragments (Max 150)</label>
+                    <input type="number" id="fragments" value="150" class="w-full border rounded p-2 text-gray-900 focus-visible:ring-2 focus-visible:ring-blue-500 outline-none">
                 </div>
 
-                <button onclick="testAssembly()" class="bg-blue-600 text-white px-6 py-2 rounded font-bold hover:bg-blue-700 w-full mt-4">Execute Assembly Metrics</button>
+                <button onclick="testAssembly()" class="bg-blue-600 text-white px-6 py-2 rounded font-bold hover:bg-blue-700 w-full mt-4 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 outline-none">Execute Assembly Metrics</button>
             </div>
 
             <div id="results" class="mt-6 hidden">


### PR DESCRIPTION
### 💡 What
Improved accessibility for the form in `frontend/templates/accounts/director_documentary.html` by properly associating labels and adding visible focus rings.

### 🎯 Why
Native HTML forms without explicit `<label for="...">` mapping and missing `:focus-visible` styles on interactive elements create significant barriers for keyboard and screen-reader users, even when using utility classes like Tailwind. Screen readers can't associate the label with the input, and keyboard users can't see which element is currently focused.

### ♿ Accessibility
- Added `for="topic"` and `for="fragments"` to the labels to programmatically link them to their respective inputs.
- Added `focus-visible:ring-2 focus-visible:ring-blue-500 outline-none` to inputs and buttons to ensure a clear, high-contrast focus indicator is shown when navigating via keyboard.

---
*PR created automatically by Jules for task [1248284051650125845](https://jules.google.com/task/1248284051650125845) started by @DevAIEngine*