### PR TITLE
🎨 Palette: Add explicit label mapping and focus states to forms

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2024-05-01 - Form Accessibility and Focus States in Tailwind Templates
+**Learning:** Native HTML templates utilizing utility classes like Tailwind need explicit `<label>` mappings using the `for` attribute to inputs for screen readers to correctly interpret form fields. Focus states should also be added using utility classes (e.g., `focus-visible:ring-2`) instead of injecting custom `<style>` blocks for better accessibility.
+**Action:** Always map labels to their corresponding inputs with `for` attributes and provide clear focus indicators on interactive elements.

--- a/frontend/templates/accounts/director_documentary.html
+++ b/frontend/templates/accounts/director_documentary.html
@@ -26,15 +26,15 @@
 
             <div class="space-y-4">
                 <div>
-                    <label class="block text-sm font-medium mb-1">Breaking News Topic</label>
-                    <input type="text" id="topic" value="Aerospace Engineering History" class="w-full border rounded p-2 text-gray-900">
+                    <label for="topic" class="block text-sm font-medium mb-1">Breaking News Topic</label>
+                    <input type="text" id="topic" value="Aerospace Engineering History" class="w-full border rounded p-2 text-gray-900 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none">
                 </div>
                 <div>
-                    <label class="block text-sm font-medium mb-1">Requested Fragments (Max 150)</label>
-                    <input type="number" id="fragments" value="150" class="w-full border rounded p-2 text-gray-900">
+                    <label for="fragments" class="block text-sm font-medium mb-1">Requested Fragments (Max 150)</label>
+                    <input type="number" id="fragments" value="150" class="w-full border rounded p-2 text-gray-900 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none">
                 </div>
 
-                <button onclick="testAssembly()" class="bg-blue-600 text-white px-6 py-2 rounded font-bold hover:bg-blue-700 w-full mt-4">Execute Assembly Metrics</button>
+                <button onclick="testAssembly()" class="bg-blue-600 text-white px-6 py-2 rounded font-bold hover:bg-blue-700 w-full mt-4 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:ring-offset-2">Execute Assembly Metrics</button>
             </div>
 
             <div id="results" class="mt-6 hidden">


### PR DESCRIPTION
🎨 Palette: Add explicit label mapping and focus states to forms

**What:** Added `for` attributes to labels and `focus-visible` classes to inputs and buttons in `director_documentary.html`.
**Why:** Native HTML templates using Tailwind utility classes lacked explicit label mappings and keyboard focus indicators, causing accessibility issues for screen readers and keyboard users.
**Accessibility:** Improved keyboard navigability by ensuring focus rings are visible on inputs and buttons, and mapped labels so screen readers properly associate them with input fields.

---
*PR created automatically by Jules for task [15432503268823997216](https://jules.google.com/task/15432503268823997216) started by @DevAIEngine*