### PR TITLE
🎨 Palette: Improve form accessibility and focus states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-05-01 - explicitly map label tags and define focus states
+**Learning:** Native HTML templates utilizing utility classes like Tailwind in this project (e.g., in `frontend/templates/`) lacked explicitly mapped `<label>` tags to inputs using the `for` attribute and focus states.
+**Action:** Improve form accessibility by explicitly mapping `<label>` tags to inputs using the `for` attribute and applying focus states via utility classes (e.g., `focus-visible:ring-2`).

--- a/frontend/templates/accounts/audio_cloning.html
+++ b/frontend/templates/accounts/audio_cloning.html
@@ -26,12 +26,12 @@
 
             <div class="space-y-4">
                 <div>
-                    <label class="block text-sm font-medium mb-1">Voice Cloning Text String</label>
-                    <textarea id="text_string" rows="4" class="w-full border rounded p-2 text-gray-900">Breaking news update: Orbital mechanics confirmed.</textarea>
+                    <label for="text_string" class="block text-sm font-medium mb-1">Voice Cloning Text String</label>
+                    <textarea id="text_string" rows="4" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500">Breaking news update: Orbital mechanics confirmed.</textarea>
                 </div>
                 <div>
-                    <label class="block text-sm font-medium mb-1">Generated Audio Requests</label>
-                    <input type="number" id="requests" value="1000" class="w-full border rounded p-2 text-gray-900">
+                    <label for="requests" class="block text-sm font-medium mb-1">Generated Audio Requests</label>
+                    <input type="number" id="requests" value="1000" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500">
                 </div>
 
                 <button onclick="testCloning()" class="bg-purple-600 text-white px-6 py-2 rounded font-bold hover:bg-purple-700 w-full mt-4">Execute API Stress Test</button>

--- a/frontend/templates/accounts/director_documentary.html
+++ b/frontend/templates/accounts/director_documentary.html
@@ -26,12 +26,12 @@
 
             <div class="space-y-4">
                 <div>
-                    <label class="block text-sm font-medium mb-1">Breaking News Topic</label>
-                    <input type="text" id="topic" value="Aerospace Engineering History" class="w-full border rounded p-2 text-gray-900">
+                    <label for="topic" class="block text-sm font-medium mb-1">Breaking News Topic</label>
+                    <input type="text" id="topic" value="Aerospace Engineering History" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
                 </div>
                 <div>
-                    <label class="block text-sm font-medium mb-1">Requested Fragments (Max 150)</label>
-                    <input type="number" id="fragments" value="150" class="w-full border rounded p-2 text-gray-900">
+                    <label for="fragments" class="block text-sm font-medium mb-1">Requested Fragments (Max 150)</label>
+                    <input type="number" id="fragments" value="150" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
                 </div>
 
                 <button onclick="testAssembly()" class="bg-blue-600 text-white px-6 py-2 rounded font-bold hover:bg-blue-700 w-full mt-4">Execute Assembly Metrics</button>


### PR DESCRIPTION
💡 **What:** Added `for` attributes to labels and `focus-visible:ring-2` to inputs in `audio_cloning.html` and `director_documentary.html`.
🎯 **Why:** To improve form accessibility. Screen readers require explicitly mapped labels to announce inputs correctly, and keyboard users need visible focus indicators to know which element is active.
📸 **Before/After:** See attached Playwright verification screenshots and video.
♿ **Accessibility:** Fixes WCAG criteria regarding explicit labels and focus visibility.

---
*PR created automatically by Jules for task [10586685359411764134](https://jules.google.com/task/10586685359411764134) started by @DevAIEngine*