### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing authentication on stream endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+
+## 2025-05-06 - Sentinel Secured GUCE Streaming Endpoint 🛡️
+**Vulnerability:** Missing authentication on the sensitive `/api/v1/capture/stream` endpoint in `backend/main.py`. This endpoint initializes live WebSocket/Stream connections for A-Roll and Gemini Live Scene Decomposition. Without authentication, any user could potentially trigger this endpoint, leading to unauthorized access, resource exhaustion, or abuse of the core engine.
+**Learning:** The FastAPI application lacked a global or endpoint-specific security dependency for this critical entrypoint, exposing a core function of the engine.
+**Prevention:** Always secure sensitive endpoints that initiate state changes or allocate resources (like stream connections) with robust authentication, such as the `HTTPBearer` dependency utilizing `hmac.compare_digest` for secure token validation against expected environment variables like `GUCE_API_KEY`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,23 @@ from fastapi import FastAPI, HTTPException, BackgroundTasks
 from pydantic import BaseModel
 import uuid
 import logging
+import os
+import hmac
+from fastapi import Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+security = HTTPBearer()
+
+def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    expected_api_key = os.environ.get("GUCE_API_KEY")
+    if not expected_api_key:
+        raise HTTPException(status_code=500, detail="Server Configuration Error: Missing API Key")
+
+    if not hmac.compare_digest(credentials.credentials, expected_api_key):
+        raise HTTPException(status_code=401, detail="Invalid API Key")
+
+    return credentials.credentials
+
 
 # Configure Logging for Epistemic Stability
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - [%(levelname)s] - %(message)s")
@@ -24,7 +41,7 @@ class ProjectManifest(BaseModel):
     scenes: list = []
 
 @app.post("/api/v1/capture/stream", response_model=ProjectManifest)
-async def start_capture_stream(user_id: str, background_tasks: BackgroundTasks):
+async def start_capture_stream(user_id: str, background_tasks: BackgroundTasks, token: str = Depends(get_current_user)):
     """
     Entrypoint for the Cell Phone First UI.
     Initializes a live WebSocket/Stream connection for A-Roll and Gemini Live Scene Decomposition.

--- a/test_backend_main.py
+++ b/test_backend_main.py
@@ -1,0 +1,39 @@
+import pytest
+import os
+import sys
+from fastapi.testclient import TestClient
+
+# Mock missing dependencies
+from unittest.mock import MagicMock
+import sys
+
+sys.path.insert(0, os.path.abspath("backend"))
+
+from main import app
+
+client = TestClient(app)
+
+def test_health_check():
+    response = client.get("/health")
+    assert response.status_code == 200
+
+def test_capture_stream_no_auth():
+    response = client.post("/api/v1/capture/stream?user_id=123")
+    assert response.status_code in [401, 403]
+
+def test_capture_stream_invalid_auth():
+    os.environ["GUCE_API_KEY"] = "secret"
+    response = client.post("/api/v1/capture/stream?user_id=123", headers={"Authorization": "Bearer bad_secret"})
+    assert response.status_code == 401
+
+def test_capture_stream_valid_auth():
+    os.environ["GUCE_API_KEY"] = "secret"
+    response = client.post("/api/v1/capture/stream?user_id=123", headers={"Authorization": "Bearer secret"})
+    assert response.status_code == 200
+    assert response.json()["user_id"] == "123"
+
+def test_capture_stream_missing_env_var():
+    if "GUCE_API_KEY" in os.environ:
+        del os.environ["GUCE_API_KEY"]
+    response = client.post("/api/v1/capture/stream?user_id=123", headers={"Authorization": "Bearer secret"})
+    assert response.status_code == 500


### PR DESCRIPTION
- Added `HTTPBearer` authentication to the critical `/api/v1/capture/stream` endpoint in `backend/main.py`.
- Used `hmac.compare_digest` to safely compare incoming tokens with the expected `GUCE_API_KEY` from the environment, protecting against timing attacks.
- Secured the default state to fail safely with a 500 error if the `GUCE_API_KEY` isn't configured on the server.
- Built a comprehensive unit test suite in `test_backend_main.py` utilizing FastAPI's `TestClient` to verify missing auth, invalid auth, valid auth, and missing server configuration scenarios.
- Ran all tests successfully.
- Added a new entry in the `.jules/sentinel.md` journal detailing the critical vulnerability found and the learning regarding FastAPI security dependencies.

---
*PR created automatically by Jules for task [18077003540180137761](https://jules.google.com/task/18077003540180137761) started by @DevAIEngine*