### PR TITLE
🎨 Palette: Improve Form Label Accessibility and Keyboard Focus

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+
+## 2026-05-07 - [Improve Form Accessibility]
+**Learning:** HTML templates lacked explicit `for` attributes on `<label>` elements mapping to their corresponding input fields, and lacked visual focus indicators for keyboard navigation.
+**Action:** Added `for` attributes to labels to properly link them with inputs (improving screen reader accessibility and label clickability) and applied Tailwind `focus-visible` utility classes to inputs to provide clear focus outlines for keyboard users.

--- a/frontend/templates/accounts/audio_cloning.html
+++ b/frontend/templates/accounts/audio_cloning.html
@@ -26,12 +26,12 @@
 
             <div class="space-y-4">
                 <div>
-                    <label class="block text-sm font-medium mb-1">Voice Cloning Text String</label>
-                    <textarea id="text_string" rows="4" class="w-full border rounded p-2 text-gray-900">Breaking news update: Orbital mechanics confirmed.</textarea>
+                    <label for="text_string" class="block text-sm font-medium mb-1">Voice Cloning Text String</label>
+                    <textarea id="text_string" rows="4" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500">Breaking news update: Orbital mechanics confirmed.</textarea>
                 </div>
                 <div>
-                    <label class="block text-sm font-medium mb-1">Generated Audio Requests</label>
-                    <input type="number" id="requests" value="1000" class="w-full border rounded p-2 text-gray-900">
+                    <label for="requests" class="block text-sm font-medium mb-1">Generated Audio Requests</label>
+                    <input type="number" id="requests" value="1000" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500">
                 </div>
 
                 <button onclick="testCloning()" class="bg-purple-600 text-white px-6 py-2 rounded font-bold hover:bg-purple-700 w-full mt-4">Execute API Stress Test</button>

--- a/frontend/templates/accounts/director_documentary.html
+++ b/frontend/templates/accounts/director_documentary.html
@@ -26,12 +26,12 @@
 
             <div class="space-y-4">
                 <div>
-                    <label class="block text-sm font-medium mb-1">Breaking News Topic</label>
-                    <input type="text" id="topic" value="Aerospace Engineering History" class="w-full border rounded p-2 text-gray-900">
+                    <label for="topic" class="block text-sm font-medium mb-1">Breaking News Topic</label>
+                    <input type="text" id="topic" value="Aerospace Engineering History" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
                 </div>
                 <div>
-                    <label class="block text-sm font-medium mb-1">Requested Fragments (Max 150)</label>
-                    <input type="number" id="fragments" value="150" class="w-full border rounded p-2 text-gray-900">
+                    <label for="fragments" class="block text-sm font-medium mb-1">Requested Fragments (Max 150)</label>
+                    <input type="number" id="fragments" value="150" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500">
                 </div>
 
                 <button onclick="testAssembly()" class="bg-blue-600 text-white px-6 py-2 rounded font-bold hover:bg-blue-700 w-full mt-4">Execute Assembly Metrics</button>

--- a/frontend/templates/accounts/scholar_compactor.html
+++ b/frontend/templates/accounts/scholar_compactor.html
@@ -26,8 +26,8 @@
 
             <div class="space-y-4">
                 <div>
-                    <label class="block text-sm font-medium mb-1">Raw Chat Export (Hyperlinks)</label>
-                    <textarea id="chat_links" rows="6" class="w-full border rounded p-2 text-gray-900">https://medical-journals.org/triage
+                    <label for="chat_links" class="block text-sm font-medium mb-1">Raw Chat Export (Hyperlinks)</label>
+                    <textarea id="chat_links" rows="6" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-green-500">https://medical-journals.org/triage
 https://nasa.gov/orbital-mechanics
 https://wikipedia.org/wiki/physics</textarea>
                 </div>

--- a/frontend/templates/accounts/tester_benchmark.html
+++ b/frontend/templates/accounts/tester_benchmark.html
@@ -29,8 +29,8 @@
                 </div>
 
                 <div>
-                    <label class="block text-sm font-medium mb-1">Concurrent Webhooks / Sec</label>
-                    <input type="range" min="1" max="1000" value="100" class="w-full" id="load_slider" oninput="document.getElementById('load_val').innerText = this.value">
+                    <label for="load_slider" class="block text-sm font-medium mb-1">Concurrent Webhooks / Sec</label>
+                    <input type="range" min="1" max="1000" value="100" class="w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500" id="load_slider" oninput="document.getElementById('load_val').innerText = this.value">
                     <div class="text-right text-sm font-bold text-orange-500"><span id="load_val">100</span> Req/s</div>
                 </div>
 


### PR DESCRIPTION
This PR improves form accessibility by:
- Adding `for` attributes to `<label>` elements so they correctly map to the `id` of their corresponding inputs/textareas. This improves screen reader experience and allows clicking the label to focus the input.
- Adding Tailwind `focus:outline-none focus-visible:ring-2` utility classes to inputs and textareas to ensure keyboard users have a clear visual focus indicator.
- Updated `.jules/palette.md` with these learnings.

---
*PR created automatically by Jules for task [13962572506008730922](https://jules.google.com/task/13962572506008730922) started by @DevAIEngine*