### PR TITLE
🎨 Palette: Dynamically Localized ARIA Labels for Language Selector

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-08 - [Dynamic ARIA Labels for Multilingual UIs]
+**Learning:** When building multilingual interfaces (like SeniorFriendlyGeminiUI) with dynamic text, ARIA labels for language selectors and other generic elements shouldn't be hardcoded to English. Screen readers depend on localized `aria-label` attributes for accessibility.
+**Action:** Extend localization objects (e.g., `translations`) with ARIA-specific keys (like `ariaLanguageSelector`) and dynamically inject them via `aria-label={translations[language].ariaLanguageSelector}`. Ensure strict TypeScript types (e.g., `keyof typeof translations`) instead of casting to `any`.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -12,24 +12,26 @@ interface GeminiMessage {
   suggestedClips?: Array<{ title: string; url: string }>;
 }
 
+// Translations & Cultural Voice Personas
+const translations = {
+  "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator", ariaLanguageSelector: "Select language" },
+  "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela", ariaLanguageSelector: "Seleccionar idioma" },
+  "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder", ariaLanguageSelector: "选择语言" },
+  "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial", ariaLanguageSelector: "Pumili ng wika" },
+  "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle", ariaLanguageSelector: "Chọn ngôn ngữ" },
+  "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller", ariaLanguageSelector: "اختر لغة" }
+};
+
+type Language = keyof typeof translations;
+
 // ============================================================
 // Component: The "Cinematic Legacy" Engine (NEXUS-LEGACY)
 // ============================================================
 export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId }) => {
   const [messages, setMessages] = useState<GeminiMessage[]>([]);
   const [isCalling, setIsCalling] = useState(false);
-  const [language, setLanguage] = useState("English");
+  const [language, setLanguage] = useState<Language>("English");
   const videoRef = useRef<HTMLVideoElement>(null);
-
-  // Translations & Cultural Voice Personas
-  const translations = {
-    "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator" },
-    "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela" },
-    "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder" },
-    "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial" },
-    "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle" },
-    "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller" }
-  };
 
   // WebSocket for Gemini live conversation
   const clientRef = useRef<W3CWebSocket | null>(null);
@@ -118,7 +120,8 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </h1>
               <select
                   value={language}
-                  onChange={(e) => setLanguage(e.target.value)}
+                  onChange={(e) => setLanguage(e.target.value as Language)}
+                  aria-label={translations[language].ariaLanguageSelector}
                   style={{ fontSize: "24px", padding: "10px", backgroundColor: "#005f73", color: "#fff", border: "none", borderRadius: "8px", cursor: "pointer" }}
               >
                   {Object.keys(translations).map(lang => (


### PR DESCRIPTION
💡 **What:** Added localized ARIA labels to the language selector dropdown in `SeniorFriendlyGeminiUI` and strictly typed the language state.
🎯 **Why:** Screen readers need localized labels for interactive elements. Hardcoding "Select Language" in English breaks the experience for users operating in Spanish, Mandarin, etc. 
♿ **Accessibility:** Dynamically assigns the `aria-label` based on the currently selected `language` state. 

*Also created a journal entry in `.Jules/palette.md` noting this pattern for future multilingual interfaces.*

---
*PR created automatically by Jules for task [4576926975835067684](https://jules.google.com/task/4576926975835067684) started by @DevAIEngine*