### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing authentication on streaming endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+
+## 2026-05-09 - [Missing Authentication on Streaming API Endpoint]
+**Vulnerability:** The `/api/v1/capture/stream` endpoint in `backend/main.py` was completely exposed with no authentication. Anyone could initialize a live WebSocket stream and potentially abuse the Gemini Live backend and system resources without supplying a valid `GUCE_API_KEY`.
+**Learning:** The streaming endpoint is the primary ingress point and its access protection was skipped. Furthermore, when verifying string-based secrets like API keys in FastAPI middleware/dependencies, standard equality (`==`) operators expose the system to timing attacks.
+**Prevention:** Always secure all entry points. Ensure that when checking authentication headers against an API key, we use `hmac.compare_digest` to perform a constant-time comparison.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,7 @@
-from fastapi import FastAPI, HTTPException, BackgroundTasks
+from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import hmac
+import os
 from pydantic import BaseModel
 import uuid
 import logging
@@ -23,8 +26,23 @@ class ProjectManifest(BaseModel):
     language: str = "en"
     scenes: list = []
 
+
+
+security = HTTPBearer()
+
+def verify_api_key(credentials: HTTPAuthorizationCredentials = Depends(security)):
+    expected_token = os.environ.get("GUCE_API_KEY")
+    if not expected_token:
+        logger.error("GUCE_API_KEY is not configured")
+        raise HTTPException(status_code=500, detail="API key not configured")
+    if not hmac.compare_digest(credentials.credentials, expected_token):
+        logger.warning("Invalid API key provided")
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return credentials.credentials
+
+
 @app.post("/api/v1/capture/stream", response_model=ProjectManifest)
-async def start_capture_stream(user_id: str, background_tasks: BackgroundTasks):
+async def start_capture_stream(user_id: str, background_tasks: BackgroundTasks, token: str = Depends(verify_api_key)):
     """
     Entrypoint for the Cell Phone First UI.
     Initializes a live WebSocket/Stream connection for A-Roll and Gemini Live Scene Decomposition.


### PR DESCRIPTION
## 🚨 Severity: CRITICAL
## 💡 Vulnerability: The primary ingress streaming endpoint `/api/v1/capture/stream` was missing authentication, leaving it publicly exposed to abuse.
## 🎯 Impact: Unauthenticated users could initialize WebSocket streams, consume backend resources (like Gemini Live), and bypass the system's intended protections. Furthermore, doing string comparison with `==` on API keys exposes the system to timing attacks.
## 🔧 Fix: Secured the endpoint using `HTTPBearer` dependency injection in FastAPI. Validates the incoming token securely against the `GUCE_API_KEY` environment variable using `hmac.compare_digest` to prevent timing attacks.
## ✅ Verification: Run `python3 -m pytest test_auth_guard.py` or the full test suite (`make test`) which confirms 401/403 responses for missing/invalid keys and 200 responses for valid keys.

---
*PR created automatically by Jules for task [12421129385153174210](https://jules.google.com/task/12421129385153174210) started by @DevAIEngine*