### PR TITLE
🎨 Palette: [UX improvement] Dynamic localized ARIA labels for language selector

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-05-17 - Dynamic Localized ARIA Labels
+**Learning:** Hardcoding English `aria-label` attributes on elements with dynamically localized text creates an inaccessible experience for non-English screen reader users. Furthermore, to dynamically look up these labels without type warnings, the localization dictionary must be strongly typed (e.g., using `useState<keyof typeof translations>`), which requires moving the object outside the React component or declaring its type before the hook.
+**Action:** Always extend the main localization object with ARIA-specific keys and use `keyof typeof` typing to safely inject language-specific `aria-label`s onto buttons and inputs.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -12,24 +12,26 @@ interface GeminiMessage {
   suggestedClips?: Array<{ title: string; url: string }>;
 }
 
+// Translations & Cultural Voice Personas
+const translations = {
+  "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator", ariaLangSelect: "Select language" },
+  "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela", ariaLangSelect: "Seleccionar idioma" },
+  "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder", ariaLangSelect: "选择语言" },
+  "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial", ariaLangSelect: "Pumili ng wika" },
+  "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle", ariaLangSelect: "Chọn ngôn ngữ" },
+  "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller", ariaLangSelect: "اختر اللغة" }
+};
+
 // ============================================================
 // Component: The "Cinematic Legacy" Engine (NEXUS-LEGACY)
 // ============================================================
+
 export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId }) => {
   const [messages, setMessages] = useState<GeminiMessage[]>([]);
   const [isCalling, setIsCalling] = useState(false);
-  const [language, setLanguage] = useState("English");
+  const [language, setLanguage] = useState<keyof typeof translations>("English");
   const videoRef = useRef<HTMLVideoElement>(null);
 
-  // Translations & Cultural Voice Personas
-  const translations = {
-    "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator" },
-    "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela" },
-    "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder" },
-    "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial" },
-    "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle" },
-    "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller" }
-  };
 
   // WebSocket for Gemini live conversation
   const clientRef = useRef<W3CWebSocket | null>(null);
@@ -117,8 +119,9 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
                   <span style={{ fontSize: "56px" }}>🎥</span> AI Director
               </h1>
               <select
+                  aria-label={translations[language].ariaLangSelect}
                   value={language}
-                  onChange={(e) => setLanguage(e.target.value)}
+                  onChange={(e) => setLanguage(e.target.value as keyof typeof translations)}
                   style={{ fontSize: "24px", padding: "10px", backgroundColor: "#005f73", color: "#fff", border: "none", borderRadius: "8px", cursor: "pointer" }}
               >
                   {Object.keys(translations).map(lang => (


### PR DESCRIPTION
💡 What: Refactored the `translations` object in `SeniorFriendlyGeminiUI.tsx` outside the React component to enable `keyof typeof` typing, and added a dynamic, localized `aria-label` to the language `<select>` dropdown.
🎯 Why: The language dropdown previously lacked an accessible name, making it difficult for screen reader users to identify its purpose. Furthermore, hardcoding an English `aria-label` on a multilingual interface breaks accessibility for non-English users.
📸 Before/After: Before, the `<select>` tag had no label. Now, it has an `aria-label={translations[language].ariaLangSelect}` that updates dynamically based on the current UI language.
♿ Accessibility: Ensures WCAG compliance by providing an accessible name for the dropdown, localized perfectly to match the current interface language. Additionally, preserved WCAG 2.5.3 compliance on the action buttons by ensuring they rely on their visible text.

---
*PR created automatically by Jules for task [10023316900625783190](https://jules.google.com/task/10023316900625783190) started by @DevAIEngine*