### PR TITLE
🎨 Palette: Add focus states and label associations to Director form

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-19 - Added ARIA focus and label association to Director Documentary Form
+**Learning:** Native HTML templates utilizing Tailwind often lack explicit label associations and focus visible states out-of-the-box, which are essential for accessibility.
+**Action:** Always ensure `<label>` elements have a `for` attribute matching the `id` of their input, and apply utility classes like `focus:outline-none focus-visible:ring-2` to inputs and buttons for keyboard navigation visibility.

--- a/frontend/templates/accounts/director_documentary.html
+++ b/frontend/templates/accounts/director_documentary.html
@@ -17,7 +17,7 @@
     <div class="max-w-4xl mx-auto mt-10 p-6">
         <div class="flex justify-between items-center mb-8">
             <h1 class="text-3xl font-bold text-blue-600">Director Jules: Documentary Production</h1>
-            <button onclick="document.body.classList.toggle('dark-mode')" class="text-sm font-semibold text-gray-500 hover:text-blue-500">Toggle Theme</button>
+            <button onclick="document.body.classList.toggle('dark-mode')" class="text-sm font-semibold text-gray-500 hover:text-blue-500 focus:outline-none focus-visible:ring-2">Toggle Theme</button>
         </div>
 
         <div class="card">
@@ -26,15 +26,15 @@
 
             <div class="space-y-4">
                 <div>
-                    <label class="block text-sm font-medium mb-1">Breaking News Topic</label>
-                    <input type="text" id="topic" value="Aerospace Engineering History" class="w-full border rounded p-2 text-gray-900">
+                    <label for="topic" class="block text-sm font-medium mb-1">Breaking News Topic</label>
+                    <input type="text" id="topic" value="Aerospace Engineering History" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2">
                 </div>
                 <div>
-                    <label class="block text-sm font-medium mb-1">Requested Fragments (Max 150)</label>
-                    <input type="number" id="fragments" value="150" class="w-full border rounded p-2 text-gray-900">
+                    <label for="fragments" class="block text-sm font-medium mb-1">Requested Fragments (Max 150)</label>
+                    <input type="number" id="fragments" value="150" class="w-full border rounded p-2 text-gray-900 focus:outline-none focus-visible:ring-2">
                 </div>
 
-                <button onclick="testAssembly()" class="bg-blue-600 text-white px-6 py-2 rounded font-bold hover:bg-blue-700 w-full mt-4">Execute Assembly Metrics</button>
+                <button onclick="testAssembly()" class="bg-blue-600 text-white px-6 py-2 rounded font-bold hover:bg-blue-700 w-full mt-4 focus:outline-none focus-visible:ring-2">Execute Assembly Metrics</button>
             </div>
 
             <div id="results" class="mt-6 hidden">


### PR DESCRIPTION
### 💡 What
Added explicit `for` attributes to the labels in `frontend/templates/accounts/director_documentary.html` to associate them with their respective inputs. Also added Tailwind CSS focus indicator classes (`focus:outline-none focus-visible:ring-2`) to the inputs and action buttons.

### 🎯 Why
Native HTML templates using Tailwind often lack out-of-the-box keyboard focus states and proper label associations. Without these, users relying on keyboard navigation wouldn't know which element was currently focused, and screen reader users would struggle to understand what data each input expects.

### 📸 Before/After
- **Before:** Form inputs had labels but were unassociated (missing `for` attributes matching input `id`s). Interactive elements lacked visual focus indicators when navigating by keyboard.
- **After:** Labels are correctly associated (`for="topic"`, `for="fragments"`). Inputs and buttons display a clear ring when focused via keyboard (`focus-visible:ring-2`).

### ♿ Accessibility
- Fixed missing form control label associations for screen readers.
- Added visual focus indicators for keyboard-only navigation.

---
*PR created automatically by Jules for task [14452143592438968894](https://jules.google.com/task/14452143592438968894) started by @DevAIEngine*