### PR TITLE
🎨 Palette: [Accessibility improvements for buttons and language select]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - Accessibility enhancements to interactive elements
+**Learning:** Hardcoding English `aria-label` attributes on elements with dynamically localized text is bad UX. TypeScript strictly types React hook inputs using object keys, so type coercion (e.g. `e.target.value as keyof typeof translations`) is needed to avoid block-scoped variable compilation errors when extracting translation state out of the component.
+**Action:** Extend the translation object with ARIA-specific localized strings, and use the TypeScript `as` operator for event handling when strict typing state from an extracted configuration object.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -206,10 +206,13 @@ export const NexusLegacyApp: React.FC = () => {
       <p style={{ color: "#94a3b8", fontSize: "28px", fontStyle: "italic", marginBottom: "60px" }}>Tell me about your first car...</p>
 
       <button
+        aria-label="End voice session"
         onClick={() => setIsVoiceOnlyMode(false)}
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>
@@ -221,7 +224,7 @@ export const NexusLegacyApp: React.FC = () => {
     <div style={{ backgroundColor: "#0f172a", minHeight: "100vh", color: "white", padding: "40px", fontFamily: "sans-serif" }}>
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderBottom: "1px solid #334155", paddingBottom: "20px", marginBottom: "40px" }}>
         <h1 style={{ fontSize: "32px", fontWeight: "bold", color: "#38bdf8" }}>⚡ Studio Edit: {userName}'s Legacy</h1>
-        <button onClick={() => alert("Exporting to TikTok/Instagram Reels...")} style={{ backgroundColor: "#ec4899", padding: "10px 20px", borderRadius: "8px", fontWeight: "bold", border: "none", cursor: "pointer" }}>Share to Socials</button>
+        <button aria-label="Share legacy to social media" onClick={() => alert("Exporting to TikTok/Instagram Reels...")} style={{ backgroundColor: "#ec4899", padding: "10px 20px", borderRadius: "8px", fontWeight: "bold", border: "none", cursor: "pointer" }}>Share to Socials</button>
       </div>
 
       <div style={{ display: "flex", gap: "40px" }}>
@@ -341,6 +344,7 @@ export const NexusLegacyApp: React.FC = () => {
 
       {/* Global Mode Toggle (Hidden for Seniors, Visible for Youth) */}
       <button
+        aria-label={isCreatorMode ? "Exit Creator Mode" : "Enter Creator Mode"}
         onClick={handleToggleMode}
         style={{
           position: "absolute", top: "20px", right: "20px", zIndex: 1000,

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -15,21 +15,21 @@ interface GeminiMessage {
 // ============================================================
 // Component: The "Cinematic Legacy" Engine (NEXUS-LEGACY)
 // ============================================================
+// Translations & Cultural Voice Personas
+const translations = {
+  "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator", ariaLangSelect: "Select language" },
+  "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela", ariaLangSelect: "Seleccionar idioma" },
+  "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder", ariaLangSelect: "选择语言" },
+  "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial", ariaLangSelect: "Pumili ng wika" },
+  "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle", ariaLangSelect: "Chọn ngôn ngữ" },
+  "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller", ariaLangSelect: "اختر اللغة" }
+};
+
 export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId }) => {
   const [messages, setMessages] = useState<GeminiMessage[]>([]);
   const [isCalling, setIsCalling] = useState(false);
-  const [language, setLanguage] = useState("English");
+  const [language, setLanguage] = useState<keyof typeof translations>("English");
   const videoRef = useRef<HTMLVideoElement>(null);
-
-  // Translations & Cultural Voice Personas
-  const translations = {
-    "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator" },
-    "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela" },
-    "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder" },
-    "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial" },
-    "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle" },
-    "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller" }
-  };
 
   // WebSocket for Gemini live conversation
   const clientRef = useRef<W3CWebSocket | null>(null);
@@ -117,8 +117,9 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
                   <span style={{ fontSize: "56px" }}>🎥</span> AI Director
               </h1>
               <select
+                  aria-label={translations[language].ariaLangSelect}
                   value={language}
-                  onChange={(e) => setLanguage(e.target.value)}
+                  onChange={(e) => setLanguage(e.target.value as keyof typeof translations)}
                   style={{ fontSize: "24px", padding: "10px", backgroundColor: "#005f73", color: "#fff", border: "none", borderRadius: "8px", cursor: "pointer" }}
               >
                   {Object.keys(translations).map(lang => (


### PR DESCRIPTION
### 💡 What
This PR adds essential missing ARIA labels to several interactive elements and ensures that dynamically styled custom buttons have proper visual focus states for keyboard navigation.

### 🎯 Why
Some buttons rely entirely on their visual context or icons (like the "Share to Socials" button or the Global Mode toggle), which creates a confusing experience for screen reader users. Additionally, the "End Session" button used custom inline event handlers (`onMouseOver`/`onMouseOut`) for hover effects, but completely ignored keyboard focus (`onFocus`/`onBlur`), meaning keyboard users received zero visual feedback when tabbing to it. 

### 📸 Before/After
**Before:**
- Language `<select>` dropdown lacked an accessible name.
- Icon-heavy buttons had no `aria-label`.
- Tabbing to the "End Session" button showed no visual change.

**After:**
- Language `<select>` is now announced with a dynamically localized string (e.g., "Select language", "Seleccionar idioma").
- Buttons are explicitly labeled.
- Tabbing to the "End Session" button correctly triggers the `#ef4444` background color.

### ♿ Accessibility
- Added `aria-label` to the main language selection dropdown.
- Added descriptive `aria-label` to the "End Session", "Share to Socials", and Creator Mode toggle buttons.
- Duplicated `onMouseOver`/`onMouseOut` styles to `onFocus`/`onBlur` for custom interactive elements to ensure equivalent keyboard focus indicators.

---
*PR created automatically by Jules for task [15574148077003449404](https://jules.google.com/task/15574148077003449404) started by @DevAIEngine*