### PR TITLE
🎨 Palette: Add dynamic ARIA label to language selector

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+
+## 2026-05-21 - [Dynamic ARIA Labels for Multilingual UIs]
+**Learning:** Hardcoding English `aria-label`s on elements with dynamically localized text is an anti-pattern that breaks the experience for international screen reader users. Furthermore, typing `useState` and `onChange` explicitly prevents TypeScript compilation errors.
+**Action:** Always extend the component's localization object (`translations`) with ARIA-specific keys. Move the object outside the component block and strongly type it using `keyof typeof` to allow dynamic, accessible updates to `aria-label` attributes based on the currently selected language.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -12,25 +12,24 @@ interface GeminiMessage {
   suggestedClips?: Array<{ title: string; url: string }>;
 }
 
+// Translations & Cultural Voice Personas
+  const translations = {
+    "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator", ariaSelectLanguage: "Select Language" },
+    "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela", ariaSelectLanguage: "Seleccionar idioma" },
+    "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder", ariaSelectLanguage: "选择语言" },
+    "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial", ariaSelectLanguage: "Pumili ng wika" },
+    "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle", ariaSelectLanguage: "Chọn ngôn ngữ" },
+    "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller", ariaSelectLanguage: "اختر اللغة" }
+  };
+
 // ============================================================
 // Component: The "Cinematic Legacy" Engine (NEXUS-LEGACY)
 // ============================================================
 export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId }) => {
   const [messages, setMessages] = useState<GeminiMessage[]>([]);
   const [isCalling, setIsCalling] = useState(false);
-  const [language, setLanguage] = useState("English");
+  const [language, setLanguage] = useState<keyof typeof translations>("English");
   const videoRef = useRef<HTMLVideoElement>(null);
-
-  // Translations & Cultural Voice Personas
-  const translations = {
-    "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator" },
-    "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela" },
-    "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder" },
-    "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial" },
-    "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle" },
-    "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller" }
-  };
-
   // WebSocket for Gemini live conversation
   const clientRef = useRef<W3CWebSocket | null>(null);
 
@@ -118,7 +117,8 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </h1>
               <select
                   value={language}
-                  onChange={(e) => setLanguage(e.target.value)}
+                  aria-label={translations[language].ariaSelectLanguage}
+                  onChange={(e) => setLanguage(e.target.value as keyof typeof translations)}
                   style={{ fontSize: "24px", padding: "10px", backgroundColor: "#005f73", color: "#fff", border: "none", borderRadius: "8px", cursor: "pointer" }}
               >
                   {Object.keys(translations).map(lang => (


### PR DESCRIPTION
💡 What:
Refactored the `translations` object to sit outside the component, typed the `useState` and `onChange` handler for robust TypeScript adherence, and added dynamically changing `aria-label`s to the language dropdown `<select>`.

🎯 Why:
Screen readers reading the AI Director dropdown lacked context on what the `<select>` element did. This fix gives screen readers the proper translated label ("Select language", "Seleccionar idioma", etc.). Furthermore, fixing the typing prevents potential compiler errors in the future.

📸 Before/After:
Before: `<select value={language} onChange={(e) => setLanguage(e.target.value)}>` (no aria-label).
After: `<select value={language} aria-label={translations[language].ariaSelectLanguage} onChange={(e) => setLanguage(e.target.value as keyof typeof translations)}>` (with full strong typing).

♿ Accessibility:
Significantly improves accessibility for international users leveraging assistive technologies to interact with the multi-lingual AI interface by providing localized descriptions.

---
*PR created automatically by Jules for task [9444711533330438251](https://jules.google.com/task/9444711533330438251) started by @DevAIEngine*