### PR TITLE
🎨 Palette: Add keyboard focus states to End Session button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-05-23 - Keyboard Focus States for Inline Hover Styles
+**Learning:** Components in this application often rely on React's inline event handlers (e.g., `onMouseOver`, `onMouseOut`) to achieve hover effects instead of using standard CSS pseudo-classes (`:hover`). This approach inherently leaves out keyboard users who navigate via `Tab`.
+**Action:** When working with inline hover handlers, always explicitly replicate those exact style changes in `onFocus` and `onBlur` handlers to ensure equivalent visual focus indicators are provided for accessibility.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -210,6 +210,8 @@ export const NexusLegacyApp: React.FC = () => {
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>


### PR DESCRIPTION
### 💡 What
Added explicit `onFocus` and `onBlur` handlers to the "End Session" button in `frontend/NEXUS_LEGACY_APP.tsx`.

### 🎯 Why
The button previously relied exclusively on inline `onMouseOver` and `onMouseOut` event handlers to achieve its visual hover state (changing the background color to `#ef4444`). This meant that keyboard users navigating via `Tab` received no visual indication that the button had received focus, breaking WCAG guidelines for focus visibility.

### 📸 Before/After
**Before:**
```tsx
<button
  ...
  onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
  onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
>
```

**After:**
```tsx
<button
  ...
  onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
  onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
  onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
  onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
>
```

### ♿ Accessibility
This change ensures that screen reader and keyboard-only users receive equivalent visual feedback to mouse users when interacting with this critical action button.

---
*PR created automatically by Jules for task [5117189466762346025](https://jules.google.com/task/5117189466762346025) started by @DevAIEngine*