### PR TITLE
🎨 Palette: Fix Missing Keyboard Focus Indicators

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+
+## 2026-05-24 - [Fix Missing Keyboard Focus Indicators]
+**Learning:** When applying custom interaction styles (like background color changes on hover) using inline React event handlers (`onMouseOver` and `onMouseOut`), keyboard users miss out on those cues unless equivalent `onFocus` and `onBlur` handlers are explicitly added.
+**Action:** Always replicate `onMouseOver`/`onMouseOut` logic in `onFocus`/`onBlur` when using inline style interactions to ensure visual focus indicators are present for keyboard navigation.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -210,6 +210,8 @@ export const NexusLegacyApp: React.FC = () => {
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>


### PR DESCRIPTION
💡 **What**: Added `onFocus` and `onBlur` handlers to the "End Session" button in `frontend/NEXUS_LEGACY_APP.tsx` to replicate existing mouse hover styles (`onMouseOver`/`onMouseOut`).
🎯 **Why**: When applying custom interaction styles (like background color changes) using inline React event handlers for mouse events, keyboard users navigating via `Tab` miss out on visual cues unless equivalent focus handlers are explicitly added.
📸 **Before/After**: Keyboard users could focus on the button but received no visual indication. Now, the button correctly highlights red when focused.
♿ **Accessibility**: Significant improvement for keyboard-only users who rely on clear visual focus indicators to navigate the interface.

---
*PR created automatically by Jules for task [4960175988656365966](https://jules.google.com/task/4960175988656365966) started by @DevAIEngine*