### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage in API error response

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+
+## 2026-05-25 - Information Leakage in API Error Responses
+**Vulnerability:** Information leakage due to returning raw exception strings in API responses.
+**Learning:** In Flask and other frameworks, directly returning `str(e)` to the client can expose internal implementation details, stack traces, or other sensitive information, which can be useful to an attacker.
+**Prevention:** Securely log the raw error on the server side (`app.logger.error`) and return a standardized, sanitized, and generic error message to the client (`{"error": "An internal server error occurred"}`).

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error("Publish error: %s", str(e))
+        return jsonify({'error': 'An internal server error occurred'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Information leakage due to returning raw exception strings (`str(e)`) in the `/api/publish` endpoint's error response within `infrastructure/app.py`.
🎯 **Impact:** Exposing internal implementation details, stack traces, or other sensitive information in API responses can assist attackers in understanding the application's structure and finding further vulnerabilities.
🔧 **Fix:** Modified the exception handler to securely log the raw error on the server side using `app.logger.error("Publish error: %s", str(e))` and return a standardized, sanitized, and generic error message (`{"error": "An internal server error occurred"}`) to the client.
✅ **Verification:** Verified that tests pass via `make test`. A manual review of the endpoint confirms that raw exceptions are no longer leaked to the client.

---
*PR created automatically by Jules for task [14450148100250095434](https://jules.google.com/task/14450148100250095434) started by @DevAIEngine*