### PR TITLE
🎨 Palette: Add keyboard focus states to 'End Session' button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-25 - [Accessibility improvements]
+**Learning:** Learned to apply accessibility features such as equivalent keyboard events.
+**Action:** Always replicate `onMouseOver` and `onMouseOut` handlers in `onFocus` and `onBlur` to ensure equivalent visual focus indicators for keyboard-only users.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -210,6 +210,8 @@ export const NexusLegacyApp: React.FC = () => {
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>


### PR DESCRIPTION
🎨 Palette: Add keyboard focus states to 'End Session' button

💡 What: Added `onFocus` and `onBlur` handlers to the 'End Session' button in `frontend/NEXUS_LEGACY_APP.tsx`.
🎯 Why: The button previously used only `onMouseOver` and `onMouseOut` to manage dynamic background colors, which made the interactive state invisible to keyboard-only users navigating via the Tab key.
📸 Before/After: Visual focus indicator was absent on focus before, and now matches the hover state.
♿ Accessibility: Ensures equivalent visual focus indicators for keyboard-only users, aligning with WCAG standards for visible focus.

---
*PR created automatically by Jules for task [8257875575105618089](https://jules.google.com/task/8257875575105618089) started by @DevAIEngine*