### PR TITLE
🎨 Palette: Add keyboard focus states to End Session button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-05-28 - [Keyboard Focus Parity for Inline Hover Styles]
+**Learning:** Found custom interaction styles (e.g., hover background colors) applied to interactive elements using inline React event handlers like `onMouseOver` and `onMouseOut` without keyboard equivalents.
+**Action:** Explicitly replicated those styles in `onFocus` and `onBlur` handlers to ensure equivalent visual focus indicators for keyboard-only users.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -210,6 +210,8 @@ export const NexusLegacyApp: React.FC = () => {
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>


### PR DESCRIPTION
💡 What: Added `onFocus` and `onBlur` handlers to the "End Session" button in the Voice Glow mode of the legacy UI.
🎯 Why: To provide a visual focus indicator for keyboard users navigating the interface.
📸 Before/After: N/A - Visuals are the same, this is an accessibility change allowing keyboard users to see visual focus mirroring mouse interaction.
♿ Accessibility: Replicates the `onMouseOver` hover state (`#ef4444`) to the `onFocus` state, and the `onMouseOut` state (`rgba(239, 68, 68, 0.2)`) to the `onBlur` state to meet basic accessibility standards for interactive elements styled with inline React handlers.

---
*PR created automatically by Jules for task [5415315628728228764](https://jules.google.com/task/5415315628728228764) started by @DevAIEngine*