### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+## 2025-05-29 - Prevent Information Leakage in API Responses
+**Vulnerability:** Raw exceptions (`str(e)`) were being returned directly to the client in `infrastructure/app.py` when an error occurred in the `/api/publish` endpoint.
+**Learning:** This is a common pattern in rapid prototyping that can easily leak internal system states, stack traces, or other sensitive infrastructure details to malicious actors.
+**Prevention:** Always log the raw exception server-side for debugging using `app.logger.error`, and return a sanitized, generic error message (like "An internal server error occurred") to the client.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error(f'Operation failed: {str(e)}')
+        return jsonify({'error': 'An internal server error occurred'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🚨 Severity: MEDIUM

💡 Vulnerability: The `/api/publish` endpoint in `infrastructure/app.py` previously exposed raw exception strings (`str(e)`) directly to the client in the response payload.

🎯 Impact: This flaw could leak sensitive internal application states, stack traces, database schema details, or infrastructure configurations to malicious actors, aiding them in formulating further targeted attacks.

🔧 Fix: Replaced the raw exception exposure with a generic user-facing message ("An internal server error occurred") and added server-side logging using `app.logger.error()` to preserve debugging capabilities securely.

✅ Verification: Verified using `grep` that `str(e)` is no longer returned in the `jsonify` payload in `infrastructure/app.py` and that the test suite still passes successfully using `make test`.

---
*PR created automatically by Jules for task [10787160229791804078](https://jules.google.com/task/10787160229791804078) started by @DevAIEngine*