### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Exposure Through Error Message in publish API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+
+## 2026-05-31 - Prevent Information Leakage in Publish API
+**Vulnerability:** The `/api/publish` endpoint in `infrastructure/app.py` returned the raw exception string `str(e)` directly in the JSON response payload.
+**Learning:** Exposing raw exception strings can leak sensitive internal state, stack traces, or configuration details to malicious actors querying the API, which violates the "Fail securely" principle.
+**Prevention:** Always log the full exception string to internal server logs (`app.logger.error()`) for debugging purposes, but return a sanitized, generic error message (e.g., "An internal server error occurred") to the API client.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error(f"Publication failed: {str(e)}")
+        return jsonify({'error': 'An internal server error occurred'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/publish` endpoint in `infrastructure/app.py` returned the raw exception string `str(e)` directly in the JSON response payload.
🎯 Impact: Exposing raw exception strings can leak sensitive internal state, stack traces, or configuration details to malicious actors querying the API, violating the "Fail securely" principle and facilitating potential targeted attacks based on exposed internal details.
🔧 Fix: Captured the raw exception and logged it to the server's internal logging (`app.logger.error`) while returning a generic, sanitized error message ("An internal server error occurred") to the API client.
✅ Verification: Ran the full backend test suite to ensure the API still functions nominally and no regressions were introduced. The source code was manually verified to reflect the sanitized `except` block.

---
*PR created automatically by Jules for task [16718004786610304570](https://jules.google.com/task/16718004786610304570) started by @DevAIEngine*