### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage in API error response

### DIFF
--- a/backend/guce/integrations/watchdog.py
+++ b/backend/guce/integrations/watchdog.py
@@ -70,6 +70,7 @@ class AsynchronousHandoffWatchdog:
             logger.error(f"[ERROR] Payload {filepath} is not valid JSON. Ignoring.")
         except Exception as e:
             logger.error(f"[ERROR] Failed to process payload {filepath}: {str(e)}")
+            # Sanitized output would go here, but this is a background process
 
         finally:
             self._archive_payload(filepath)

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -4,6 +4,9 @@ from googleapiclient.discovery import build
 import os
 import uuid
 import datetime
+import logging
+
+logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 
@@ -74,7 +77,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        logger.error(f'Publish failed: {str(e)}')
+        return jsonify({'error': 'An internal error occurred during publish operation'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `/api/publish` endpoint in `infrastructure/app.py` was catching generic exceptions and returning the raw exception string to the client (`return jsonify({'error': str(e)}), 500`). This is an information leakage vulnerability because it can expose sensitive internal details, stack traces, or configuration data to an attacker.
🎯 **Impact:** Exposing raw exception strings could provide an attacker with a deeper understanding of the system's internal workings, which could aid them in crafting more targeted exploits.
🔧 **Fix:** I modified the `except` block to log the actual exception internally using `logger.error(f'Publish failed: {str(e)}')` and then return a generic, sanitized error message to the client (`return jsonify({'error': 'An internal error occurred during publish operation'}), 500`).
✅ **Verification:** I verified the fix by checking the file modifications and running the test suite (`make test`), ensuring all 4 tests passed.

---
*PR created automatically by Jules for task [7050519400671429399](https://jules.google.com/task/7050519400671429399) started by @DevAIEngine*