### PR TITLE
🛡️ Sentinel: [HIGH] Fix Information Disclosure in API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+
+## 2026-03-20 - Information Leakage in API Responses
+**Vulnerability:** Raw exception strings (`str(e)`) were being returned directly to the client in the `/api/publish` endpoint's error response.
+**Learning:** Returning unhandled exception messages to clients can leak sensitive internal implementation details, such as database schemas, file paths, or third-party service errors.
+**Prevention:** Always log the raw error securely on the server-side and return a standardized, sanitized error message to the client to prevent information disclosure.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -4,6 +4,9 @@ from googleapiclient.discovery import build
 import os
 import uuid
 import datetime
+import logging
+
+logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 
@@ -74,7 +77,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        logger.error(f'Error during publish: {str(e)}')
+        return jsonify({'error': 'An internal error occurred during the publishing process.'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🛡️ **Sentinel: [HIGH] Fix Information Disclosure**

🚨 **Severity:** HIGH
💡 **Vulnerability:** Raw exception strings (`str(e)`) were being returned directly to the client in the `/api/publish` endpoint's error response (Information Leakage).
🎯 **Impact:** Returning unhandled exception messages to clients can leak sensitive internal implementation details, such as database schemas, file paths, or third-party service errors.
🔧 **Fix:** Secured the error handler by replacing the exposed exception text with a standardized, sanitized error message (`An internal error occurred during the publishing process.`). The raw exception is now safely logged server-side via the standard Python `logging` module.
✅ **Verification:** Verified by inspecting the changes and running `make test` which executed successfully without regressions. Added a critical learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2819345166902058558](https://jules.google.com/task/2819345166902058558) started by @DevAIEngine*