### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage in /api/publish

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+
+## 2026-06-08 - Information Leakage in API Responses
+**Vulnerability:** Raw exception strings (str(e)) returned directly to the client in HTTP 500 responses.
+**Learning:** Exposing internal exception details can reveal sensitive system information, infrastructure paths, or logic flaws to potential attackers.
+**Prevention:** Always catch exceptions securely by logging the raw error server-side and returning a generic, sanitized error message to the client.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error(f'Publish error: {e}')
+        return jsonify({'error': 'An internal server error occurred'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information Leakage - the `/api/publish` endpoint caught exceptions and directly returned `str(e)` in the HTTP 500 response.
🎯 Impact: Attackers could gain insights into the application's internal workings, filesystem paths, database structures, or external API failures, aiding further attacks.
🔧 Fix: Modified the exception handler to log the raw exception internally via `app.logger` and return a generic, sanitized "An internal server error occurred" message.
✅ Verification: Verified the exception block now logs the error and returns a generic message instead of `str(e)`.

---
*PR created automatically by Jules for task [6356262810659929730](https://jules.google.com/task/6356262810659929730) started by @DevAIEngine*