### PR TITLE
🎨 Palette: Add localized ARIA labels to multilingual select

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+
+## 2024-06-08 - Dynamic ARIA Labels in Multilingual Components
+**Learning:** Hardcoding English `aria-label` attributes on elements with dynamically localized text creates a confusing experience for non-English screen reader users.
+**Action:** Extend the central localization object (e.g., `translations[language]`) with ARIA-specific keys and apply them dynamically. Ensure the localization object is declared before the hook call or outside the component, and use TypeScript's `keyof typeof translations` for the state hook to prevent compilation errors when casting event targets.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -15,21 +15,21 @@ interface GeminiMessage {
 // ============================================================
 // Component: The "Cinematic Legacy" Engine (NEXUS-LEGACY)
 // ============================================================
+// Translations & Cultural Voice Personas
+const translations = {
+  "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator", ariaLabel: "Select language" },
+  "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela", ariaLabel: "Seleccionar idioma" },
+  "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder", ariaLabel: "选择语言" },
+  "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial", ariaLabel: "Piliin ang wika" },
+  "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle", ariaLabel: "Chọn ngôn ngữ" },
+  "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller", ariaLabel: "اختر اللغة" }
+};
+
 export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId }) => {
   const [messages, setMessages] = useState<GeminiMessage[]>([]);
   const [isCalling, setIsCalling] = useState(false);
-  const [language, setLanguage] = useState("English");
+  const [language, setLanguage] = useState<keyof typeof translations>("English");
   const videoRef = useRef<HTMLVideoElement>(null);
-
-  // Translations & Cultural Voice Personas
-  const translations = {
-    "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator" },
-    "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela" },
-    "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder" },
-    "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial" },
-    "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle" },
-    "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller" }
-  };
 
   // WebSocket for Gemini live conversation
   const clientRef = useRef<W3CWebSocket | null>(null);
@@ -117,8 +117,9 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
                   <span style={{ fontSize: "56px" }}>🎥</span> AI Director
               </h1>
               <select
+                  aria-label={translations[language].ariaLabel}
                   value={language}
-                  onChange={(e) => setLanguage(e.target.value)}
+                  onChange={(e) => setLanguage(e.target.value as keyof typeof translations)}
                   style={{ fontSize: "24px", padding: "10px", backgroundColor: "#005f73", color: "#fff", border: "none", borderRadius: "8px", cursor: "pointer" }}
               >
                   {Object.keys(translations).map(lang => (


### PR DESCRIPTION
### 💡 What
Added dynamic, localized `aria-label` values to the multilingual `<select>` dropdown in `SeniorFriendlyGeminiUI.tsx`.

### 🎯 Why
Hardcoding an English `aria-label` on an element containing dynamically translated text causes confusion for screen reader users relying on localized interfaces. This ensures the accessibility tree matches the visual and audible language context.

### 📸 Before/After
**Before:** `<select>` element had no `aria-label` resulting in poor screen reader context.
**After:** `<select>` element uses `aria-label={translations[language].ariaLabel}`, ensuring the label context accurately matches the currently active persona language.

### ♿ Accessibility
- Dramatically improves screen reader navigation by accurately announcing the purpose of the language selector in the native language being selected.
- Prevented potential compilation errors by enforcing strict TypeScript types on the language state hook (`keyof typeof translations`).

---
*PR created automatically by Jules for task [12238151818547741579](https://jules.google.com/task/12238151818547741579) started by @DevAIEngine*