### PR TITLE
🎨 Palette: Added screen reader ARIA attributes to Gemini UI

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2024-06-10 - Screen Reader Focus for Dynamically Updating Chat
+**Learning:** When adding `aria-live="polite"` to dynamically updating message containers (like a chat interface), it ensures screen readers gracefully announce new messages without ripping the focus away from the user. Also, putting the language select ARIA label into the translations object makes it localized!
+**Action:** Always add `aria-live="polite"` to chat or message output divs, and localize ARIA labels alongside the rest of the text content.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -12,25 +12,26 @@ interface GeminiMessage {
   suggestedClips?: Array<{ title: string; url: string }>;
 }
 
+
+
+  // Translations & Cultural Voice Personas
+  const translations = {
+    "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator", ariaLangSelect: "Select language" },
+    "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela", ariaLangSelect: "Seleccionar idioma" },
+    "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder", ariaLangSelect: "选择语言" },
+    "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial", ariaLangSelect: "Pumili ng wika" },
+    "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle", ariaLangSelect: "Chọn ngôn ngữ" },
+    "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller", ariaLangSelect: "اختر اللغة" }
+  };
+
 // ============================================================
 // Component: The "Cinematic Legacy" Engine (NEXUS-LEGACY)
 // ============================================================
 export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId }) => {
   const [messages, setMessages] = useState<GeminiMessage[]>([]);
   const [isCalling, setIsCalling] = useState(false);
-  const [language, setLanguage] = useState("English");
+  const [language, setLanguage] = useState<keyof typeof translations>("English");
   const videoRef = useRef<HTMLVideoElement>(null);
-
-  // Translations & Cultural Voice Personas
-  const translations = {
-    "English": { greeting: "Tell me about your first car.", btnCall: "ANSWER CALL", btnEnd: "END SESSION", tone: "Respectful narrator" },
-    "Español": { greeting: "Cuéntame sobre tu primer auto.", btnCall: "CONTESTAR", btnEnd: "TERMINAR", tone: "Warm, friendly abuela" },
-    "中文": { greeting: "告诉我你的第一辆车。", btnCall: "接听", btnEnd: "结束", tone: "Wise elder" },
-    "Tagalog": { greeting: "Sabihin mo sa akin ang tungkol sa iyong unang kotse.", btnCall: "SAGUTIN", btnEnd: "BABAAN", tone: "Warm and familial" },
-    "Tiếng Việt": { greeting: "Kể cho tôi nghe về chiếc xe đầu tiên của bạn.", btnCall: "TRẢ LỜI", btnEnd: "KẾT THÚC", tone: "Respectful and gentle" },
-    "العربية": { greeting: "أخبرني عن سيارتك الأولى.", btnCall: "إجابة", btnEnd: "إنهاء", tone: "Storyteller" }
-  };
-
   // WebSocket for Gemini live conversation
   const clientRef = useRef<W3CWebSocket | null>(null);
 
@@ -117,8 +118,9 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
                   <span style={{ fontSize: "56px" }}>🎥</span> AI Director
               </h1>
               <select
+                  aria-label={translations[language].ariaLangSelect}
                   value={language}
-                  onChange={(e) => setLanguage(e.target.value)}
+                  onChange={(e) => setLanguage(e.target.value as keyof typeof translations)}
                   style={{ fontSize: "24px", padding: "10px", backgroundColor: "#005f73", color: "#fff", border: "none", borderRadius: "8px", cursor: "pointer" }}
               >
                   {Object.keys(translations).map(lang => (
@@ -161,7 +163,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
### 💡 What
Added `aria-live="polite"` to the chat message container and a localized `aria-label` to the language `<select>` dropdown in `SeniorFriendlyGeminiUI.tsx`.

### 🎯 Why
To ensure screen readers can gracefully announce new dynamic messages in the "Cinematic Legacy" engine without stealing user focus, and to provide properly localized names for the language selector. 

### 📸 Before/After
*(Visuals remain unchanged, this is purely an underlying accessibility enhancement)*

### ♿ Accessibility
- Added `aria-live="polite"` so new messages are read out loud as they append.
- Added localized `ariaLangSelect` to the `translations` object so the language dropdown's ARIA label changes dynamically with the selected persona language.
- Safely refactored `translations` out of the component scope and strictly typed the language selection hook.

---
*PR created automatically by Jules for task [3916624920906659598](https://jules.google.com/task/3916624920906659598) started by @DevAIEngine*