### PR TITLE
🎨 Palette: Add keyboard focus indicators to End Session button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-06-12 - Inline React Focus Styles
+**Learning:** When applying custom interaction styles (like hover background colors) using inline React event handlers (`onMouseOver`/`onMouseOut`), those styles aren't automatically applied to keyboard focus states.
+**Action:** Always explicitly replicate those styles in `onFocus` and `onBlur` handlers to ensure equivalent visual focus indicators for keyboard-only users.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -210,6 +210,8 @@ export const NexusLegacyApp: React.FC = () => {
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>


### PR DESCRIPTION
### 💡 What
Added explicitly mapped `onFocus` and `onBlur` inline React event handlers to the "End Session" button in the Voice Only mode, applying the exact same style changes previously only triggered by `onMouseOver` and `onMouseOut`.

### 🎯 Why
The custom hover styles (a red background transition) on this button were implemented using inline React `onMouseOver` events rather than standard CSS hover states. Because of this, the style change was entirely missing for users navigating with a keyboard, violating accessibility standards by leaving no visual focus indicator.

### 📸 Before/After
*   **Before:** Tabbed keyboard focus applied no visual change.
*   **After:** Tabbed keyboard focus mimics the visual hover transition, filling the button with red to indicate active focus.

### ♿ Accessibility
*   Improves WCAG compliance (Success Criterion 2.4.7 Focus Visible). Keyboard-only users and screen reader users navigating linearly now have equivalent visual feedback to mouse users.

---
*PR created automatically by Jules for task [12188655306623092054](https://jules.google.com/task/12188655306623092054) started by @DevAIEngine*