### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage in publish API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+## 2026-06-13 - Information Leakage in Publish API
+**Vulnerability:** The `/api/publish` endpoint in `infrastructure/app.py` returned raw exception strings (`str(e)`) to the client when an error occurred.
+**Learning:** Returning raw exception details can expose internal system state, file paths, or sensitive data to potential attackers, aiding in reconnaissance.
+**Prevention:** Catch exceptions globally or locally, log the raw exception details securely on the server side using the application logger, and return a standardized, sanitized, generic error message to the client.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error(f"Error during publish: {str(e)}")
+        return jsonify({'error': 'An internal error occurred during publication.'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `/api/publish` endpoint in `infrastructure/app.py` returned raw exception strings (`str(e)`) to the client when an error occurred. This could expose internal system state, file paths, or sensitive data to potential attackers.
🎯 **Impact:** Information exposure aids attackers in reconnaissance, potentially allowing them to understand the backend architecture or craft more targeted exploits based on leaked details.
🔧 **Fix:** Replaced the raw exception return with a generic error message (`"An internal error occurred during publication."`) and securely logged the actual exception details using `app.logger.error`.
✅ **Verification:** Verified the code changes by reading the updated `infrastructure/app.py` file to ensure the raw `str(e)` response was replaced and the logger was implemented. Ran `make test` to confirm no regressions were introduced.

---
*PR created automatically by Jules for task [13294229477754166741](https://jules.google.com/task/13294229477754166741) started by @DevAIEngine*