### PR TITLE
🎨 Palette: Add keyboard focus styles and ARIA live regions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2024-06-13 - Focus Styles & Live Regions
+**Learning:** Found inline hover styles without corresponding focus styles and dynamic content updates lacking ARIA live regions.
+**Action:** Pair `onMouseOver`/`onMouseOut` styles with `onFocus`/`onBlur` handlers for keyboard accessibility. Add `aria-live="polite"` to containers that update dynamically to ensure screen readers announce changes.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -210,6 +210,8 @@ export const NexusLegacyApp: React.FC = () => {
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }} aria-live="polite">
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
🎯 **Why:** The "End Session" button lacked a visual focus state, making it difficult for keyboard-only users to know when it was focused. Additionally, incoming AI messages in the Gemini UI were dynamically inserted without notifying screen readers, leaving visually impaired users unaware of new content.

💡 **What:** 
- Replicated existing `onMouseOver`/`onMouseOut` styles in `onFocus`/`onBlur` for the "End Session" button.
- Added `aria-live="polite"` to the message container div.

📸 **Before/After:**
- **Before:** Keyboard focus on "End Session" was invisible. Screen readers ignored new messages.
- **After:** Keyboard focus triggers the same visual state as hover. Screen readers announce new messages as they appear.
*(See attached verification video/screenshot for technical confirmation)*

♿ **Accessibility:**
- Improves WCAG 2.4.7 Focus Visible compliance.
- Improves WCAG 4.1.3 Status Messages compliance via ARIA live regions.

---
*PR created automatically by Jules for task [135767130312501795](https://jules.google.com/task/135767130312501795) started by @DevAIEngine*