### PR TITLE
🎨 Palette: Add keyboard focus states and screen reader announcements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2024-06-15 - Equivalent Visual Focus Indicators
+**Learning:** When using inline React event handlers like `onMouseOver` for custom hover styles, keyboard users lose vital interactive feedback if not replicated.
+**Action:** Always mirror `onMouseOver` and `onMouseOut` inline styles with identical `onFocus` and `onBlur` handlers to preserve keyboard accessibility.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -210,6 +210,8 @@ export const NexusLegacyApp: React.FC = () => {
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -117,6 +117,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
                   <span style={{ fontSize: "56px" }}>🎥</span> AI Director
               </h1>
               <select
+                  aria-label="Select Voice Language"
                   value={language}
                   onChange={(e) => setLanguage(e.target.value)}
                   style={{ fontSize: "24px", padding: "10px", backgroundColor: "#005f73", color: "#fff", border: "none", borderRadius: "8px", cursor: "pointer" }}
@@ -161,7 +162,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
💡 What: Added `onFocus` and `onBlur` events to mirror `onMouseOver` hover interactions on the "End Session" button. Added an `aria-label` to the multilingual selector and `aria-live="polite"` to the live chat output container.
🎯 Why: To ensure keyboard users receive equivalent visual feedback when navigating custom styled components, and to ensure screen readers appropriately identify controls and announce dynamic live chat messages.
📸 Before/After: Visual focus rings were absent and live messages were unannounced; now focus triggers identical hover highlighting and new messages are read politely.
♿ Accessibility: Preserves keyboard operability and provides crucial context for screen reader users engaging with live Gemini features.

---
*PR created automatically by Jules for task [6298039346990238290](https://jules.google.com/task/6298039346990238290) started by @DevAIEngine*