### PR TITLE
🎨 Palette: Add aria-live to dynamically updated messages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2024-05-14 - Add aria-live for dynamically populated content
+**Learning:** Screen readers need explicit hints to announce new content arriving in dynamically populated areas (like WebSocket message feeds or AI output logs) without stealing the user's focus.
+**Action:** Always add the `aria-live="polite"` attribute to containers that dynamically update their content so screen readers announce the new text automatically.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
## 💡 What
Added the `aria-live="polite"` attribute to the dynamically populated subtitles container in `frontend/SeniorFriendlyGeminiUI.tsx`.

## 🎯 Why
When new WebSocket messages (from the user or the AI Director) are added to the DOM, screen readers need an explicit hint to announce this new content automatically without forcibly stealing the user's focus from where they are currently interacting.

## 📸 Before/After
*(Verification script confirmed structural update on about:blank DOM)*
Before: `<div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>`
After: `<div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>`

## ♿ Accessibility
Ensures screen reader users (especially important for the "Senior Friendly" persona this UI targets) can hear the live conversation transcripts as they stream in without needing to manually re-navigate to the container each time a new message arrives.

---
*PR created automatically by Jules for task [15708409878824483471](https://jules.google.com/task/15708409878824483471) started by @DevAIEngine*