### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Exposure in API Route

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+## 2026-03-18 - Information Exposure via Unhandled Exceptions
+**Vulnerability:** Returning the raw exception string `str(e)` directly to the API client on error.
+**Learning:** This exposes the internal application workings, stack traces, and potential file paths or database queries to external users, allowing attackers to footprint the system.
+**Prevention:** Always log the full exception details on the server side (`logger.error`) and return a generic, standardized error message (e.g., 'An internal server error occurred') to the client.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error(f"Publish error: {str(e)}")
+        return jsonify({'error': 'An internal server error occurred'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `/api/publish` endpoint in `infrastructure/app.py` was returning the raw exception string `str(e)` directly to the API client when an error occurred. This is a form of Information Exposure, as it could leak internal application workings, stack traces, file paths, or potentially sensitive configuration details to an attacker, aiding in footprinting the system.
🎯 **Impact:** An attacker could intentionally trigger errors (e.g., by providing malformed payloads or manipulating the environment) to glean technical details about the backend architecture, making it easier to craft targeted attacks.
🔧 **Fix:** Replaced the raw exception string returned to the client (`return jsonify({'error': str(e)}), 500`) with a safe, generic message (`return jsonify({'error': 'An internal server error occurred'}), 500`). The actual exception details are now securely logged on the server side (`app.logger.error(f"Publish error: {str(e)}")`) to ensure debugging context is retained without exposing it externally.
✅ **Verification:** Verified via `grep` that the `app.logger.error` call and generic string replacement were applied correctly. Executed the backend test suite via `make test` to ensure no functional regressions or syntax errors were introduced.

---
*PR created automatically by Jules for task [12575893176211776893](https://jules.google.com/task/12575893176211776893) started by @DevAIEngine*