### PR TITLE
🎨 Palette: Improve keyboard focus and screen reader accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+
+## 2026-03-20 - [Inline Hover States Missing Focus Equivalents & Silent Dynamic Content]
+**Learning:** Found multiple instances where interactive elements had inline `onMouseOver` styles but lacked keyboard focus states, and dynamically populated content like chat subtitles lacked `aria-live` attributes, causing screen readers to miss updates.
+**Action:** Replicated `onMouseOver`/`onMouseOut` styles in `onFocus`/`onBlur` for keyboard users, and added `aria-live="polite"` to dynamically updating UI regions like message containers.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -210,6 +210,8 @@ export const NexusLegacyApp: React.FC = () => {
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
💡 **What:**
- Replicated existing `onMouseOver`/`onMouseOut` background color styles into `onFocus`/`onBlur` event handlers on the "End Session" button in `NEXUS_LEGACY_APP.tsx`.
- Added an `aria-live="polite"` attribute to the dynamically populated subtitles container in `SeniorFriendlyGeminiUI.tsx`.

🎯 **Why:**
- Interactive elements that rely solely on `onMouseOver` for visual feedback leave keyboard users (who navigate via `Tab` and trigger `onFocus`) without clear indicators of their current position.
- Chat interfaces that append text dynamically without `aria-live` attributes silently update on the screen, causing screen reader users to miss incoming messages entirely unless they manually re-read the page.

📸 **Before/After:**
*(Visual changes affect keyboard focus states; no structural DOM changes were made that alter layout.)*

♿ **Accessibility:**
- Keyboard users now see the red highlight when tabbing to the End Session button.
- Screen reader users will now hear the Gemini AI's responses read aloud sequentially as they appear on screen without losing their current focus context.

---
*PR created automatically by Jules for task [17418033801514264576](https://jules.google.com/task/17418033801514264576) started by @DevAIEngine*