### PR TITLE
🎨 Palette: Add aria-live to subtitles container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ __pycache__/
 *.py[cod]
 *.class
 .pytest_cache/
+node_modules

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2024-06-19 - Dynamic Content Screen Reader Access
+**Learning:** Screen readers won't announce dynamically appended subtitles or chat messages unless the container has `aria-live`.
+**Action:** Always add `aria-live="polite"` to dynamically populated content containers to ensure screen readers announce new text without stealing immediate user focus.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
### 💡 What
Added the `aria-live="polite"` attribute to the container in `SeniorFriendlyGeminiUI.tsx` that renders the dynamic stream of `messages` from the Gemini AI.

### 🎯 Why
Without an `aria-live` region, when new subtitles or AI voice outputs are appended to the DOM dynamically via WebSocket, screen readers remain silent unless the user explicitly navigates to the new text. Adding `aria-live="polite"` ensures that screen readers automatically read out the incoming dialogue in the background without rudely interrupting the user's current focus, which is essential for the "Voice-to-Docu" experience.

### 📸 Before/After
*(No visual changes, purely an accessibility DOM update)*

### ♿ Accessibility
- **Screen Reader Support:** Drastically improves the experience for visually impaired users by properly announcing the incoming real-time subtitles and conversational dialogue.

---
*PR created automatically by Jules for task [14348286325524280534](https://jules.google.com/task/14348286325524280534) started by @DevAIEngine*