### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage in error response

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+## 2024-10-24 - Prevent Information Leakage in Vertex AI Pipeline Responses
+**Vulnerability:** The infrastructure API returned raw exception strings (`str(e)`) directly to the client on error.
+**Learning:** This pattern specific to the codebase exposes internal AI pipeline state and Vertex AI integration details to potential attackers, aiding in reconnaissance.
+**Prevention:** Securely log the raw error on the server side using Flask's `app.logger.error` and return a standardized, sanitized error message to the client.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error(f"Error during publish: {e}")
+        return jsonify({'error': 'An internal server error occurred while processing the request'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
## 🚨 Severity\nMEDIUM\n\n## 💡 Vulnerability\nThe `infrastructure/app.py` `/api/publish` endpoint returned raw exception strings (`str(e)`) directly to the client when an error occurred. This information leakage could expose internal AI pipeline state and Vertex AI integration details to potential attackers.\n\n## 🎯 Impact\nAttackers could use the exposed internal system details (like file paths, API connection errors, or database schema hints) for reconnaissance to identify further vulnerabilities.\n\n## 🔧 Fix\nReplaced the raw exception return with a generic, sanitized error message (`'An internal server error occurred while processing the request'`). To maintain debuggability, the actual exception is now securely logged server-side using Flask's `app.logger.error`.\n\n## ✅ Verification\n- Ran `make test` successfully.\n- Verified visually that `str(e)` is no longer returned in the JSON response payload.

---
*PR created automatically by Jules for task [10992903869265022960](https://jules.google.com/task/10992903869265022960) started by @DevAIEngine*