### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information leakage in publish endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+
+## 2026-06-25 - Information Exposure in Exception Handling
+**Vulnerability:** The `/api/publish` endpoint in `infrastructure/app.py` returned the raw exception string directly to the client (`jsonify({'error': str(e)})`).
+**Learning:** Directly exposing exception details to clients can leak sensitive system information (e.g., directory paths, configuration values, stack traces).
+**Prevention:** Catch exceptions, log the raw `str(e)` securely on the server side using the application logger, and return a standardized, non-descript error message (e.g., 'An internal server error occurred') to the client.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error(f"Publish failed: {str(e)}")
+        return jsonify({'error': 'An internal server error occurred'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/publish` endpoint in `infrastructure/app.py` was returning the raw exception string (`str(e)`) directly to the client in the JSON response upon failure.
🎯 Impact: Leaking raw exception strings can expose sensitive system internals such as directory paths, third-party API configurations, or stack traces to an attacker, facilitating further reconnaissance.
🔧 Fix: Updated the exception block to log the raw exception string securely on the server-side using `app.logger.error()` and return a standardized, non-descript error message ('An internal server error occurred') to the client.
✅ Verification: Ran the test suite via `make test` and verified the fix locally to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [4390215909508493731](https://jules.google.com/task/4390215909508493731) started by @DevAIEngine*