### PR TITLE
🎨 Palette: Add aria-live for dynamic chat announcements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-06-22 - [Dynamically Appending Messages Need ARIA Live]
+**Learning:** The cinematic chat interface in SeniorFriendlyGeminiUI dynamically appends text bubbles as the 'Director' speaks. Without an aria-live region, visually impaired users utilizing screen readers would be unaware of incoming messages, rendering the core Voice-to-Docu interface unusable.
+**Action:** Added `aria-live="polite"` to the container wrapping the dynamically mapped messages. This ensures screen readers announce new incoming text passively without aggressively stealing immediate user focus.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" aria-atomic="false" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` and `aria-atomic="false"` to the dynamic chat message container in `SeniorFriendlyGeminiUI.tsx`.
🎯 Why: To ensure screen readers announce incoming chat messages passively, making the Voice-to-Docu interface accessible to visually impaired users.
📸 Before/After: Added `aria-live="polite"` and `aria-atomic="false"` attributes to the parent `div`.
♿ Accessibility: Dramatically improved screen reader support for the core interactive component.

---
*PR created automatically by Jules for task [8141978104667327096](https://jules.google.com/task/8141978104667327096) started by @DevAIEngine*