### PR TITLE
🎨 Palette: Add aria-live to subtitles container

### DIFF
--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }} aria-live="polite">
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
**💡 What**
Added `aria-live="polite"` to the dynamically populated subtitles container in the `SeniorFriendlyGeminiUI` component.

**🎯 Why**
To ensure that new messages (subtitles) arriving from the Gemini WebSocket are automatically announced by screen readers without aggressively interrupting the user's current actions or stealing focus.

**📸 Before/After**
Before: Subtitles appeared visually but screen readers were unaware of the new content unless the user manually navigated to the container.
After: Screen readers politely announce new subtitles as they appear.

**♿ Accessibility**
This is a textbook accessibility improvement for live regions, critical for chat interfaces and live transcription, ensuring equitable access to the conversation for visually impaired users.

---
*PR created automatically by Jules for task [13364010403082769653](https://jules.google.com/task/13364010403082769653) started by @DevAIEngine*