### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Exception Information Leakage

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+## 2024-06-24 - Prevent Exception Information Leakage
+**Vulnerability:** Raw exception strings (`str(e)`) were being returned directly to the client in the `/api/publish` endpoint error response.
+**Learning:** Returning raw exception details can expose sensitive architectural information or data structures (like internal API keys, database paths, or stack traces) to malicious actors.
+**Prevention:** Always log the raw exception on the server side using the application logger, and return a standardized, sanitized error message to the client.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error(f'Error publishing: {str(e)}')
+        return jsonify({'error': 'An internal server error occurred while processing the request'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
# 🚨 Severity: MEDIUM
# 💡 Vulnerability: Raw exception strings (`str(e)`) were directly returned to the client in the 500 response of `/api/publish`.
# 🎯 Impact: Returning raw exception details can expose sensitive internal architecture, file paths, or potentially API keys/secrets to malicious actors depending on the error context.
# 🔧 Fix: Modified the exception handler to securely log the raw error via `app.logger.error` and return a generic, sanitized error message to the client.
# ✅ Verification: The API response for 500 errors no longer contains raw `Exception` strings.

---
*PR created automatically by Jules for task [14020733058078639231](https://jules.google.com/task/14020733058078639231) started by @DevAIEngine*