### PR TITLE
🎨 Palette: [Accessibility] Add aria-live polite to dynamic chat messages

### DIFF
--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
💡 **What**: Added `aria-live="polite"` to the subtitles container in `SeniorFriendlyGeminiUI.tsx`.
🎯 **Why**: To ensure that screen readers announce newly populated dynamic content (incoming chat messages) without aggressively interrupting ongoing speech.
📸 **Before/After**: The visual UI remains exactly the same, but the underlying HTML now includes `aria-live="polite"` on the flex container wrapping the messages.
♿ **Accessibility**: Significantly improves screen reader experience for users interacting with the live conversational interface.

---
*PR created automatically by Jules for task [13797595286118943606](https://jules.google.com/task/13797595286118943606) started by @DevAIEngine*