### PR TITLE
🎨 Palette: Add aria-live to subtitles container

### DIFF
--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
### 💡 What
Added `aria-live="polite"` to the subtitles container in `frontend/SeniorFriendlyGeminiUI.tsx`.

### 🎯 Why
To ensure screen readers automatically announce new incoming chat messages and AI voice output without requiring the user to manually refocus, improving the accessibility of the live conversation UI.

### 📸 Before/After
**Before:**
```tsx
<div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
```
**After:**
```tsx
<div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
```

### ♿ Accessibility
The `aria-live="polite"` attribute instructs assistive technologies to announce updates to the element's content as they happen, waiting until the user is idle before speaking to prevent abrupt interruptions.

---
*PR created automatically by Jules for task [3258292044785341426](https://jules.google.com/task/3258292044785341426) started by @DevAIEngine*