### PR TITLE
🎨 Palette: Add keyboard focus state to End Session button

### DIFF
--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -210,6 +210,8 @@ export const NexusLegacyApp: React.FC = () => {
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>


### PR DESCRIPTION
💡 What: Added `onFocus` and `onBlur` handlers to the "End Session" button in the Voice Only mode of the Legacy App.
🎯 Why: To ensure keyboard users receive the same visual feedback as mouse users when navigating to the button.
📸 Before/After: Before, keyboard navigation provided no visual focus indicator. After, focusing the button highlights it red, identical to the mouse hover state.
♿ Accessibility: Improves keyboard navigation accessibility by providing a clear visual focus indicator, satisfying WCAG criteria for focus visible.

---
*PR created automatically by Jules for task [5255009032999615485](https://jules.google.com/task/5255009032999615485) started by @DevAIEngine*