### PR TITLE
🎨 Palette: Add aria-live to subtitles output

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-03-24 - [Add aria-live to subtitles output]
+**Learning:** Dynamically populated content containers (like the AI output text in `SeniorFriendlyGeminiUI.tsx`) lack implicit screen reader support when updated async.
+**Action:** Added `aria-live="polite"` to dynamically updating text containers to ensure smooth, non-interruptive screen reader announcements for new content.

--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` to the subtitles output container in `SeniorFriendlyGeminiUI.tsx`.
🎯 Why: Ensures screen readers automatically announce new messages/subtitles as they arrive from the AI, without interrupting the user.
📸 Before/After: Visuals unchanged; functional a11y improvement for screen reader users.
♿ Accessibility: Improves dynamic content accessibility by announcing new AI outputs politely to assistive technologies.

---
*PR created automatically by Jules for task [12176106003700933247](https://jules.google.com/task/12176106003700933247) started by @DevAIEngine*