### PR TITLE
🎨 Palette: Add keyboard focus state to "End Session" button

### DIFF
--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -210,6 +210,8 @@ export const NexusLegacyApp: React.FC = () => {
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
         onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
         onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        onFocus={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
+        onBlur={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>


### PR DESCRIPTION
**💡 What:** Added `onFocus` and `onBlur` handlers to the "End Session" button in `frontend/NEXUS_LEGACY_APP.tsx`.

**🎯 Why:** The button previously only had visual interaction states mapped to `onMouseOver` and `onMouseOut`, meaning users navigating with a keyboard (like using the `Tab` key) received no visual feedback that the button was focused. This creates a state conflict where the element is focused but visually appears idle. 

**📸 Before/After:**
*Before:* Keyboard focus was invisible.
*After:* Keyboard focus perfectly matches the hover style.

**♿ Accessibility:** Improves keyboard navigation accessibility by ensuring interactive elements utilizing inline mouse event styling provide equivalent visual focus indicators.

---
*PR created automatically by Jules for task [15983769249694475412](https://jules.google.com/task/15983769249694475412) started by @DevAIEngine*