### PR TITLE
🎨 Palette: Fix interaction state conflict on studio buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2024-06-29 - Interaction State Conflict
+**Learning:** When applying custom interaction styles, using inline JS events for both hover and focus creates a state conflict (e.g., `onMouseOut` reverting styles while the element is still focused).
+**Action:** Prefer migrating visual interaction states to CSS pseudo-classes (e.g., `:hover`, `:focus-visible`) rather than relying on inline React event handlers.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -116,10 +116,7 @@ export const NexusLegacyApp: React.FC = () => {
           onClick={() => handleSelectTheme("NAT_GEO")}
           aria-label="Select Heritage Studio"
           style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
+          className="studio-btn"
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#FFD700", margin: 0 }}>Heritage Studio</h2>
@@ -132,10 +129,7 @@ export const NexusLegacyApp: React.FC = () => {
           onClick={() => handleSelectTheme("AEROSPACE")}
           aria-label="Select Aerospace Studio"
           style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
+          className="studio-btn"
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#38bdf8", margin: 0 }}>Aerospace Studio</h2>
@@ -336,6 +330,7 @@ export const NexusLegacyApp: React.FC = () => {
           .documentary-image {
             animation: kenburns-effect 12s ease-in-out infinite alternate;
           }
+          .studio-btn:hover, .studio-btn:focus-visible { transform: scale(1.05) !important; }
         `}
       </style>
 


### PR DESCRIPTION
💡 What: Replaced inline JS hover/focus event handlers on the studio buttons with native CSS `:hover` and `:focus-visible` pseudo-classes.
🎯 Why: Using both `onMouseOut` and `onFocus` creates an interaction state conflict where moving the mouse off a focused element removes its visual focus indicator, breaking keyboard accessibility.
📸 Before/After: Visuals remain identical, but state transitions are now natively managed by the browser.
♿ Accessibility: Keyboard-only users now retain a persistent, reliable visual focus indicator (scaling effect) even if the mouse pointer happens to move across the element.

---
*PR created automatically by Jules for task [6634684384604085724](https://jules.google.com/task/6634684384604085724) started by @DevAIEngine*