### PR TITLE
🎨 Palette: Refactor keyboard focus states for gallery interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+
+## 2024-07-01 - Fix keyboard accessibility focus states for React buttons
+**Learning:** React inline event handlers like `onMouseOver` and `onFocus` often create visual conflicts and jarring user experiences, especially for mouse users who trigger `onFocus` when clicking.
+**Action:** Always migrate interactive visual states (like hover and focus) from inline JS event handlers to CSS pseudo-classes (`:hover`, `:focus-visible`). This ensures proper keyboard accessibility and prevents conflicting visual states.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -284,7 +284,7 @@ export const NexusLegacyApp: React.FC = () => {
         margin: "0 auto"
       }}>
         {userAssets.map((asset, index) => (
-          <button key={asset.id} aria-label={`Play ${asset.title}`} style={{
+          <button key={asset.id} aria-label={`Play ${asset.title}`} className="bento-card" style={{
             backgroundColor: "rgba(26,26,26,0.6)",
             backdropFilter: "blur(12px)",
             borderRadius: "32px",
@@ -299,12 +299,7 @@ export const NexusLegacyApp: React.FC = () => {
             display: "block",
             width: "100%",
             height: "100%"
-          }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
-          >
+          }}>
             <img src={asset.thumbnail} alt={asset.title} className="documentary-image" style={{ width: "100%", height: "100%", objectFit: "cover", position: "absolute", zIndex: 0, opacity: 0.6 }} />
             <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)", zIndex: 1 }}>
               <h2 style={{ fontSize: index === 0 ? "48px" : "32px", margin: "0 0 10px 0", fontWeight: "bold", textShadow: "0 2px 10px rgba(0,0,0,1)" }}>{asset.title}</h2>
@@ -335,6 +330,12 @@ export const NexusLegacyApp: React.FC = () => {
           }
           .documentary-image {
             animation: kenburns-effect 12s ease-in-out infinite alternate;
+          }
+          .bento-card:hover, .bento-card:focus-visible {
+            transform: scale(1.02) translateY(-10px);
+          }
+          .bento-card {
+            transform: scale(1) translateY(0);
           }
         `}
       </style>


### PR DESCRIPTION
- 💡 **What**: Migrated inline `onMouseOver` and `onMouseOut` hover effects to CSS pseudo-classes (`:hover` and `:focus-visible`) for Bento box buttons.
- 🎯 **Why**: Using CSS pseudo-classes instead of inline events resolves state conflicts when users interact with the component, ensuring robust keyboard focus visibility for improved accessibility.
- 📸 **Before/After**: Screenshots captured during verification.
- ♿ **Accessibility**: Improved keyboard navigation visual feedback and removed state conflicts.

---
*PR created automatically by Jules for task [16694055137231819856](https://jules.google.com/task/16694055137231819856) started by @DevAIEngine*