### PR TITLE
🎨 Palette: Add aria-live polite to subtitles container

### DIFF
--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
💡 What: Added the `aria-live="polite"` attribute to the subtitle / AI Voice Output container in `frontend/SeniorFriendlyGeminiUI.tsx`.
🎯 Why: To ensure screen readers announce new subtitles as they appear in the interface without abruptly interrupting the user's focus. 
📸 Before/After: Visuals remain entirely unchanged, as this is purely a semantic markup addition.
♿ Accessibility: The chat history now correctly utilizes live regions, meaning seniors using assistive technologies will be properly updated when the AI Director responds.

---
*PR created automatically by Jules for task [3321406767692348275](https://jules.google.com/task/3321406767692348275) started by @DevAIEngine*