### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Information Leakage in /api/publish

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
  **Vulnerability:** Unpinned GitHub Action Dependency
  **Learning:** Using mutable tags (like @v0.7.0) for GitHub Actions allows a potential attacker to compromise the repository if the tag is modified or overwritten.
  **Prevention:** Always pin GitHub Actions to an immutable commit SHA to guarantee the specific code version executed and prevent supply chain attacks.
+
+## 2024-05-18 - Prevented Information Leakage via Unsanitized Error Responses
+**Vulnerability:** The `/api/publish` endpoint in `infrastructure/app.py` returned raw exception strings (`str(e)`) in its 500 JSON response, exposing potentially sensitive internal implementation details (e.g., path structures, database schemas, API token configurations).
+**Learning:** Even simple APIs intended for internal infrastructure must assume error payloads can leak to unauthorized observers. Exposing raw errors breaks the "Fail Securely" principle and can facilitate further attacks.
+**Prevention:** Always log the raw `Exception` object securely server-side and return generic, sanitized error messages (e.g., "An internal error occurred during the operation") to clients.

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error('Operation failed: %s', e)
+        return jsonify({'error': 'An internal error occurred during the operation'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `/api/publish` endpoint in `infrastructure/app.py` returned raw exception strings (`str(e)`) in its 500 JSON response, potentially exposing sensitive internal implementation details (e.g., path structures, database schemas).
🎯 Impact: This violated the "Fail Securely" principle and could facilitate further attacks by exposing internal state.
🔧 Fix: Replaced the raw error return with a secure server-side log (`app.logger.error`) and a standardized, sanitized error message to the client. Appended learning to `.jules/sentinel.md`.
✅ Verification: Ran `make test` which passed successfully. Verified the code change visually via terminal outputs to confirm the exact `app.logger.error` implementation.

---
*PR created automatically by Jules for task [12667834738940415717](https://jules.google.com/task/12667834738940415717) started by @DevAIEngine*