### PR TITLE
🎨 Palette: Migrate Inline JS Interaction States to CSS Pseudo-classes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2024-07-04 - Fixing State Conflicts on Interactive Elements
+**Learning:** Using inline JavaScript event handlers (like `onMouseOver` and `onFocus`) alongside inline styles for hover and focus states creates bugs. For example, if an element is focused using the keyboard and then hovered/unhovered with a mouse, the `onMouseOut` event triggers, removing the styles even while the element is still focused.
+**Action:** Always migrate visual interaction states from inline JS to CSS pseudo-classes (e.g., `:hover`, `:focus-visible`) to avoid state conflicts and improve both accessibility and UI consistency.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -115,11 +115,8 @@ export const NexusLegacyApp: React.FC = () => {
         <button
           onClick={() => handleSelectTheme("NAT_GEO")}
           aria-label="Select Heritage Studio"
+          className="studio-card"
           style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#FFD700", margin: 0 }}>Heritage Studio</h2>
@@ -131,11 +128,8 @@ export const NexusLegacyApp: React.FC = () => {
         <button
           onClick={() => handleSelectTheme("AEROSPACE")}
           aria-label="Select Aerospace Studio"
+          className="studio-card"
           style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#38bdf8", margin: 0 }}>Aerospace Studio</h2>
@@ -189,6 +183,15 @@ export const NexusLegacyApp: React.FC = () => {
             50% { box-shadow: 0 0 80px #FFD700, 0 0 120px #FFD700; transform: scale(1.05); }
             100% { box-shadow: 0 0 40px #FFD700, 0 0 80px #FFD700; transform: scale(1); }
           }
+          .studio-card:hover, .studio-card:focus-visible {
+            transform: scale(1.05) !important;
+          }
+          .bento-card:hover, .bento-card:focus-visible {
+            transform: scale(1.02) translateY(-10px) !important;
+          }
+          .end-session-btn:hover, .end-session-btn:focus-visible {
+            background-color: #ef4444 !important;
+          }
           .glowing-orb {
             width: 250px;
             height: 250px;
@@ -206,10 +209,9 @@ export const NexusLegacyApp: React.FC = () => {
       <p style={{ color: "#94a3b8", fontSize: "28px", fontStyle: "italic", marginBottom: "60px" }}>Tell me about your first car...</p>
 
       <button
+        className="end-session-btn"
         onClick={() => setIsVoiceOnlyMode(false)}
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
-        onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
-        onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>
@@ -300,10 +302,7 @@ export const NexusLegacyApp: React.FC = () => {
             width: "100%",
             height: "100%"
           }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
+          className="bento-card"
           >
             <img src={asset.thumbnail} alt={asset.title} className="documentary-image" style={{ width: "100%", height: "100%", objectFit: "cover", position: "absolute", zIndex: 0, opacity: 0.6 }} />
             <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)", zIndex: 1 }}>


### PR DESCRIPTION
💡 What: Replaced inline JS event handlers (`onMouseOver`, `onFocus`, etc.) with CSS pseudo-classes (`:hover`, `:focus-visible`) for `studio-card`, `end-session-btn`, and `bento-card` components in `frontend/NEXUS_LEGACY_APP.tsx`.

🎯 Why: To fix state collisions on interactive elements where, for example, hovering and then unhovering a keyboard-focused element using a mouse would trigger `onMouseOut` and incorrectly remove the focus styles while the element remained active.

📸 Before/After: Verified visual stability with Playwright testing locally. Visual styles remain identical to previous inline styling, but interaction behavior is now robust.

♿ Accessibility: The migration ensures that focus states (`:focus-visible`) remain persistent and predictable for screen readers and keyboard users regardless of overlapping mouse interactions, substantially improving the component's keyboard accessibility and reliability.

---
*PR created automatically by Jules for task [10330578086698980958](https://jules.google.com/task/10330578086698980958) started by @DevAIEngine*