### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Information Leakage in /api/publish Endpoint

### DIFF
--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -74,7 +74,8 @@ def publish():
             'scenesCount': len(scenes)
         })
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        app.logger.error(f"Publish error: {str(e)}")
+        return jsonify({'error': 'An internal error occurred.'}), 500
 
 @app.route('/api/orchestration/publish', methods=['POST'])
 def orchestration_publish():


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `/api/publish` endpoint in `infrastructure/app.py` returned raw exception messages (`str(e)`) to the client. Returning raw exceptions can expose sensitive internal system details, file paths, or configurations, leading to an information leakage vulnerability.
🎯 Impact: Attackers could potentially gather internal paths or system states which might aid in further exploitation.
🔧 Fix: Removed `str(e)` from the JSON error response and replaced it with a standardized message: `'An internal error occurred.'`. The actual raw error is now securely logged via `app.logger.error`.
✅ Verification: Ran `make test` successfully to ensure no regressions were introduced. Evaluated manually via code inspection to confirm `str(e)` is no longer returned in the `infrastructure/app.py` `/api/publish` endpoint's exception handler.

---
*PR created automatically by Jules for task [16496648507425737597](https://jules.google.com/task/16496648507425737597) started by @DevAIEngine*