### PR TITLE
🎨 Palette: Add aria-live to live message output

### DIFF
--- a/frontend/SeniorFriendlyGeminiUI.tsx
+++ b/frontend/SeniorFriendlyGeminiUI.tsx
@@ -161,7 +161,7 @@ export const SeniorFriendlyGeminiUI: React.FC<{ userId: string }> = ({ userId })
               </div>
 
               {/* Subtitles & AI Voice Output (Massive Legible Text) */}
-              <div style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
+              <div aria-live="polite" style={{ flex: 1, display: "flex", flexDirection: "column", justifyContent: "flex-end", paddingBottom: "100px" }}>
                   {messages.map((msg, idx) => (
                       <div key={idx} style={{ marginBottom: "20px", fontSize: "32px", lineHeight: "1.4" }}>
                           <strong style={{ color: msg.role === "user" ? "#4fd1c5" : "#FFD700" }}> {/* Deep Teal User vs Gold AI */}


### PR DESCRIPTION
💡 What: Added `aria-live="polite"` to the container rendering AI voice outputs and user messages.
🎯 Why: Without an aria-live region, visually impaired users utilizing screen readers would not be notified when new messages arrive in the interface.
📸 Before/After: Visuals are unchanged (only HTML attributes modified).
♿ Accessibility: Ensures that dynamic chat content is automatically announced by screen reading software, greatly enhancing accessibility for users relying on assistive technology.

---
*PR created automatically by Jules for task [11884381302061860003](https://jules.google.com/task/11884381302061860003) started by @DevAIEngine*