### PR TITLE
🎨 Palette: Migrate visual interaction states to CSS

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-03-19 - [Migrate Interaction States to CSS]
+**Learning:** Using inline JS events for both hover and focus creates a state conflict (e.g., onMouseOut reverting styles while the element is still focused).
+**Action:** Migrated visual interaction states to CSS pseudo-classes (:hover, :focus-visible) rather than relying on inline React event handlers.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -115,11 +115,8 @@ export const NexusLegacyApp: React.FC = () => {
         <button
           onClick={() => handleSelectTheme("NAT_GEO")}
           aria-label="Select Heritage Studio"
+          className="studio-btn"
           style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#FFD700", margin: 0 }}>Heritage Studio</h2>
@@ -131,11 +128,8 @@ export const NexusLegacyApp: React.FC = () => {
         <button
           onClick={() => handleSelectTheme("AEROSPACE")}
           aria-label="Select Aerospace Studio"
+          className="studio-btn"
           style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#38bdf8", margin: 0 }}>Aerospace Studio</h2>
@@ -207,9 +201,8 @@ export const NexusLegacyApp: React.FC = () => {
 
       <button
         onClick={() => setIsVoiceOnlyMode(false)}
+        className="end-session-btn"
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
-        onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
-        onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>
@@ -300,10 +293,7 @@ export const NexusLegacyApp: React.FC = () => {
             width: "100%",
             height: "100%"
           }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
+          className="bento-btn"
           >
             <img src={asset.thumbnail} alt={asset.title} className="documentary-image" style={{ width: "100%", height: "100%", objectFit: "cover", position: "absolute", zIndex: 0, opacity: 0.6 }} />
             <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)", zIndex: 1 }}>
@@ -335,6 +325,17 @@ export const NexusLegacyApp: React.FC = () => {
           }
           .documentary-image {
             animation: kenburns-effect 12s ease-in-out infinite alternate;
+          }
+
+          /* Interactive hover and focus states using CSS to prevent JS event conflicts */
+          .studio-btn:hover, .studio-btn:focus-visible {
+            transform: scale(1.05) !important;
+          }
+          .end-session-btn:hover, .end-session-btn:focus-visible {
+            background-color: #ef4444 !important;
+          }
+          .bento-btn:hover, .bento-btn:focus-visible {
+            transform: scale(1.02) translateY(-10px) !important;
           }
         `}
       </style>


### PR DESCRIPTION
💡 **What:** Migrated inline JavaScript interaction events (`onMouseOver`, `onMouseOut`, `onFocus`, `onBlur`) on the primary interactive buttons to standard CSS pseudo-classes (`:hover`, `:focus-visible`).
🎯 **Why:** Using inline JS events for both hover and focus creates a state conflict where, for example, a `mouseout` event removes the focus ring (or specific style) while the element is legitimately still focused via the keyboard, disrupting keyboard users and screen readers.
📸 **Before/After:** No visual change (transparent refactor).
♿ **Accessibility:** Prevents state conflicts between mouse interaction and keyboard focus visibility, ensuring a reliable focus indicator for keyboard users.

---
*PR created automatically by Jules for task [5975335702177855880](https://jules.google.com/task/5975335702177855880) started by @DevAIEngine*