### PR TITLE
🎨 Palette: Fix keyboard/mouse interaction state conflicts in NEXUS_LEGACY_APP

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-10-27 - Inline Interaction State Conflict Resolution
+**Learning:** Using inline JS events (e.g., `onMouseOver`, `onFocus`) for both hover and focus states creates interaction conflicts (e.g., `onMouseOut` overriding an active focus state), which breaks keyboard accessibility.
+**Action:** Always manage visual interaction states using CSS pseudo-classes (`:hover`, `:focus-visible`) to ensure reliable styling across both pointer and keyboard interactions.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -113,13 +113,10 @@ export const NexusLegacyApp: React.FC = () => {
       <div style={{ display: "flex", gap: "40px" }}>
         {/* Nat Geo Studio Button */}
         <button
+          className="studio-btn"
           onClick={() => handleSelectTheme("NAT_GEO")}
           aria-label="Select Heritage Studio"
-          style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
+          style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s, outline 0.2s", border: "none", textAlign: "left" }}
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#FFD700", margin: 0 }}>Heritage Studio</h2>
@@ -129,13 +126,10 @@ export const NexusLegacyApp: React.FC = () => {
 
         {/* Aerospace Museum Studio Button */}
         <button
+          className="studio-btn"
           onClick={() => handleSelectTheme("AEROSPACE")}
           aria-label="Select Aerospace Studio"
-          style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
+          style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s, outline 0.2s", border: "none", textAlign: "left" }}
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#38bdf8", margin: 0 }}>Aerospace Studio</h2>
@@ -206,10 +200,9 @@ export const NexusLegacyApp: React.FC = () => {
       <p style={{ color: "#94a3b8", fontSize: "28px", fontStyle: "italic", marginBottom: "60px" }}>Tell me about your first car...</p>
 
       <button
+        className="end-session-btn"
         onClick={() => setIsVoiceOnlyMode(false)}
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
-        onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
-        onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>
@@ -284,7 +277,7 @@ export const NexusLegacyApp: React.FC = () => {
         margin: "0 auto"
       }}>
         {userAssets.map((asset, index) => (
-          <button key={asset.id} aria-label={`Play ${asset.title}`} style={{
+          <button className="bento-btn" key={asset.id} aria-label={`Play ${asset.title}`} style={{
             backgroundColor: "rgba(26,26,26,0.6)",
             backdropFilter: "blur(12px)",
             borderRadius: "32px",
@@ -294,16 +287,12 @@ export const NexusLegacyApp: React.FC = () => {
             border: "1px solid rgba(255,255,255,0.1)",
             gridColumn: index === 0 ? "span 2" : "span 1", // First item spans 2 columns for the trendy Bento look
             boxShadow: "0 20px 40px rgba(0,0,0,0.5)",
-            transition: "transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+            transition: "transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), outline 0.2s",
             textAlign: "left",
             display: "block",
             width: "100%",
             height: "100%"
           }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
           >
             <img src={asset.thumbnail} alt={asset.title} className="documentary-image" style={{ width: "100%", height: "100%", objectFit: "cover", position: "absolute", zIndex: 0, opacity: 0.6 }} />
             <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)", zIndex: 1 }}>
@@ -335,6 +324,22 @@ export const NexusLegacyApp: React.FC = () => {
           }
           .documentary-image {
             animation: kenburns-effect 12s ease-in-out infinite alternate;
+          }
+          /* UX/Accessibility Improvements */
+          .studio-btn:hover, .studio-btn:focus-visible {
+            transform: scale(1.05);
+            outline: 2px solid #FFD700;
+            outline-offset: 4px;
+          }
+          .end-session-btn:hover, .end-session-btn:focus-visible {
+            background-color: #ef4444 !important;
+            outline: 2px solid #ef4444;
+            outline-offset: 4px;
+          }
+          .bento-btn:hover, .bento-btn:focus-visible {
+            transform: scale(1.02) translateY(-10px) !important;
+            outline: 2px solid #FFD700;
+            outline-offset: 4px;
           }
         `}
       </style>


### PR DESCRIPTION
💡 **What:** Replaced inline JS events (`onMouseOver`, `onFocus`, etc.) with CSS pseudo-classes (`:hover`, `:focus-visible`) for interaction states on interactive elements in `NEXUS_LEGACY_APP.tsx`.

🎯 **Why:** Using inline JS events for both hover and focus creates state conflicts (e.g., `onMouseOut` reverts styling while the element is still focused), which breaks keyboard accessibility. Migrating to CSS pseudo-classes ensures reliable and predictable styling for both pointer and keyboard users.

📸 **Before/After:**
*Before:* Keyboard focus states would disappear if the mouse cursor moved off the button while it was focused.
*After:* Hover and focus states are handled independently via CSS, ensuring focus styles remain visible until the element loses focus.

♿ **Accessibility:** This directly improves keyboard accessibility by providing reliable and persistent focus indicators for interactive elements (`:focus-visible`), which is critical for users navigating via keyboard.

---
*PR created automatically by Jules for task [15758411890913600815](https://jules.google.com/task/15758411890913600815) started by @DevAIEngine*