### PR TITLE
🎨 Palette: Migrate visual interaction states to CSS pseudo-classes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-07-10 - Migrate Inline Events to CSS Pseudo-classes
+**Learning:** When applying custom interaction styles in React components that heavily rely on inline `style={}` attributes, using inline JS events for both hover and focus creates a state conflict (e.g., `onMouseOut` reverting styles while the element is still focused). Using `!important` in injected CSS rules successfully overrides the base inline styles without requiring complete restyling.
+**Action:** Prefer migrating visual interaction states to CSS pseudo-classes (e.g., `:hover`, `:focus-visible`) rather than relying on inline React event handlers.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -115,11 +115,8 @@ export const NexusLegacyApp: React.FC = () => {
         <button
           onClick={() => handleSelectTheme("NAT_GEO")}
           aria-label="Select Heritage Studio"
+          className="interactive-scale"
           style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#FFD700", margin: 0 }}>Heritage Studio</h2>
@@ -131,11 +128,8 @@ export const NexusLegacyApp: React.FC = () => {
         <button
           onClick={() => handleSelectTheme("AEROSPACE")}
           aria-label="Select Aerospace Studio"
+          className="interactive-scale"
           style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#38bdf8", margin: 0 }}>Aerospace Studio</h2>
@@ -207,9 +201,8 @@ export const NexusLegacyApp: React.FC = () => {
 
       <button
         onClick={() => setIsVoiceOnlyMode(false)}
+        className="end-session-btn"
         style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
-        onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
-        onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
       >
         🛑 End Session
       </button>
@@ -284,7 +277,7 @@ export const NexusLegacyApp: React.FC = () => {
         margin: "0 auto"
       }}>
         {userAssets.map((asset, index) => (
-          <button key={asset.id} aria-label={`Play ${asset.title}`} style={{
+          <button key={asset.id} aria-label={`Play ${asset.title}`} className="bento-button" style={{
             backgroundColor: "rgba(26,26,26,0.6)",
             backdropFilter: "blur(12px)",
             borderRadius: "32px",
@@ -300,10 +293,6 @@ export const NexusLegacyApp: React.FC = () => {
             width: "100%",
             height: "100%"
           }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
           >
             <img src={asset.thumbnail} alt={asset.title} className="documentary-image" style={{ width: "100%", height: "100%", objectFit: "cover", position: "absolute", zIndex: 0, opacity: 0.6 }} />
             <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)", zIndex: 1 }}>
@@ -335,6 +324,16 @@ export const NexusLegacyApp: React.FC = () => {
           }
           .documentary-image {
             animation: kenburns-effect 12s ease-in-out infinite alternate;
+          }
+          .interactive-scale:hover, .interactive-scale:focus-visible {
+            transform: scale(1.05) !important;
+          }
+          .bento-button:hover, .bento-button:focus-visible {
+            transform: scale(1.02) translateY(-10px) !important;
+          }
+          .end-session-btn:hover, .end-session-btn:focus-visible {
+            background-color: #ef4444 !important;
+            color: #ffffff !important;
           }
         `}
       </style>


### PR DESCRIPTION
💡 **What:** Migrated visual interaction states from inline React event handlers to CSS pseudo-classes.
🎯 **Why:** Using inline JS events for both hover and focus creates a state conflict (e.g., `onMouseOut` reverting styles while the element is still focused).
📸 **Before/After:** Not applicable (visuals remain identical, interaction state management changed).
♿ **Accessibility:** Enhances keyboard accessibility by ensuring `:focus-visible` styles remain persistent and do not incorrectly revert due to stray mouse movements.

---
*PR created automatically by Jules for task [2377558323254315911](https://jules.google.com/task/2377558323254315911) started by @DevAIEngine*