### PR TITLE
🎨 Palette: Fix interaction state conflicts for interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,6 @@
 ## 2026-03-19 - [Fix Divs as Buttons Anti-pattern]
 **Learning:** The 'Bento Box' gallery and Studio Selectors used clickable divs. This broke keyboard navigation and screen readers for core interactive components.
 **Action:** Replaced interactive divs with semantic `<button>` tags, mapped existing `onMouseOver` visual hover states to `onFocus` for keyboard focus indicators, and added `aria-label`s for context.
+## 2026-03-20 - [Fix Interaction State Conflict]
+**Learning:** Using inline JS events (`onMouseOver`, `onFocus`) for visual feedback in React creates a state conflict where blur events override hover states.
+**Action:** Migrated interactive visual feedback from inline React event handlers to CSS pseudo-classes (`:hover`, `:focus-visible`) using `!important` to reliably override inline styles.

--- a/frontend/NEXUS_LEGACY_APP.tsx
+++ b/frontend/NEXUS_LEGACY_APP.tsx
@@ -115,11 +115,8 @@ export const NexusLegacyApp: React.FC = () => {
         <button
           onClick={() => handleSelectTheme("NAT_GEO")}
           aria-label="Select Heritage Studio"
-          style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
+          className="studio-btn"
+          style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1478760329108-5c3ed9d495a0?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", border: "none", textAlign: "left" }}
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#FFD700", margin: 0 }}>Heritage Studio</h2>
@@ -131,11 +128,8 @@ export const NexusLegacyApp: React.FC = () => {
         <button
           onClick={() => handleSelectTheme("AEROSPACE")}
           aria-label="Select Aerospace Studio"
-          style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", transition: "transform 0.3s", border: "none", textAlign: "left" }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.05)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1)"}
+          className="studio-btn"
+          style={{ width: "400px", height: "500px", backgroundImage: "url('https://images.unsplash.com/photo-1451187580459-43490279c0fa?q=80&w=800&auto=format&fit=crop')", backgroundSize: "cover", borderRadius: "32px", cursor: "pointer", position: "relative", overflow: "hidden", border: "none", textAlign: "left" }}
         >
           <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)" }}>
             <h2 style={{ fontSize: "36px", color: "#38bdf8", margin: 0 }}>Aerospace Studio</h2>
@@ -207,9 +201,8 @@ export const NexusLegacyApp: React.FC = () => {
 
       <button
         onClick={() => setIsVoiceOnlyMode(false)}
-        style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer", transition: "all 0.2s" }}
-        onMouseOver={(e) => e.currentTarget.style.backgroundColor = "#ef4444"}
-        onMouseOut={(e) => e.currentTarget.style.backgroundColor = "rgba(239, 68, 68, 0.2)"}
+        className="end-session-btn"
+        style={{ fontSize: "32px", padding: "20px 60px", backgroundColor: "rgba(239, 68, 68, 0.2)", color: "#ef4444", border: "2px solid #ef4444", borderRadius: "100px", fontWeight: "bold", cursor: "pointer" }}
       >
         🛑 End Session
       </button>
@@ -294,16 +287,12 @@ export const NexusLegacyApp: React.FC = () => {
             border: "1px solid rgba(255,255,255,0.1)",
             gridColumn: index === 0 ? "span 2" : "span 1", // First item spans 2 columns for the trendy Bento look
             boxShadow: "0 20px 40px rgba(0,0,0,0.5)",
-            transition: "transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
             textAlign: "left",
             display: "block",
             width: "100%",
             height: "100%"
           }}
-          onMouseOver={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onMouseOut={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
-          onFocus={(e) => e.currentTarget.style.transform = "scale(1.02) translateY(-10px)"}
-          onBlur={(e) => e.currentTarget.style.transform = "scale(1) translateY(0)"}
+          className="bento-btn"
           >
             <img src={asset.thumbnail} alt={asset.title} className="documentary-image" style={{ width: "100%", height: "100%", objectFit: "cover", position: "absolute", zIndex: 0, opacity: 0.6 }} />
             <div style={{ position: "absolute", bottom: 0, left: 0, right: 0, padding: "40px", background: "linear-gradient(to top, rgba(0,0,0,0.9), transparent)", zIndex: 1 }}>
@@ -333,6 +322,12 @@ export const NexusLegacyApp: React.FC = () => {
             0% { transform: scale(1.0) translate(0, 0); }
             100% { transform: scale(1.2) translate(-20px, -10px); }
           }
+          .studio-btn { transition: transform 0.3s !important; }
+          .studio-btn:hover, .studio-btn:focus-visible { transform: scale(1.05) !important; outline: 3px solid #38bdf8; outline-offset: 4px; }
+          .end-session-btn { transition: all 0.2s !important; }
+          .end-session-btn:hover, .end-session-btn:focus-visible { background-color: #ef4444 !important; outline: 3px solid #ef4444; outline-offset: 4px; }
+          .bento-btn { transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1) !important; }
+          .bento-btn:hover, .bento-btn:focus-visible { transform: scale(1.02) translateY(-10px) !important; outline: 3px solid #FFD700; outline-offset: 4px; }
           .documentary-image {
             animation: kenburns-effect 12s ease-in-out infinite alternate;
           }


### PR DESCRIPTION
💡 **What:** Migrated interactive visual feedback from inline React event handlers (`onMouseOver`, `onFocus`) to CSS pseudo-classes (`:hover`, `:focus-visible`) for the Studio selection buttons, End Session button, and Bento Box gallery items.
🎯 **Why:** To resolve an interaction state conflict where blur events erroneously override hover states (and vice-versa), ensuring consistent visual feedback for both mouse and keyboard users.
📸 **Before/After:** The exact same visual scaling and color transitions are preserved, but they are now reliably triggered by CSS state changes rather than brittle inline JS events.
♿ **Accessibility:** Added visible focus rings (`outline: 3px solid`) via the `:focus-visible` pseudo-class to clearly indicate the currently focused element during keyboard navigation.

---
*PR created automatically by Jules for task [2173037106941725041](https://jules.google.com/task/2173037106941725041) started by @DevAIEngine*